### PR TITLE
exclude cancelled items rather than orders

### DIFF
--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -245,7 +245,7 @@ def getOrders(access_token,accountId,session,reservationId,passengerId,ship,star
         orderCode = order.get("orderCode")
         
         # Only get Valid Orders That Cost Money
-        if order.get("status") == 'BOOKED' and order.get("orderTotals").get("total") > 0: 
+        if order.get("orderTotals").get("total") > 0: 
             
             # Get Order Details
             response = requests.get(
@@ -255,6 +255,9 @@ def getOrders(access_token,accountId,session,reservationId,passengerId,ship,star
             )
                     
             for orderDetail in response.json().get("payload").get("orderHistoryDetailItems"):
+                # check for cancelled status at item-level
+                if orderDetail.get("guests")[0].get("orderStatus") == "CANCELLED":
+                    continue
                 order_title = orderDetail.get("productSummary").get("title")
                 product = orderDetail.get("productSummary").get("id")
                 prefix = orderDetail.get("productSummary").get("productTypeCategory").get("id")


### PR DESCRIPTION
Cancelling an item within a multi-item order results in an "AMENDED" order status. We can work around this by looking for cancelled status at the item-level instead. Note that this still only looks at the first guest, so adding/dropping guests rather than cancelling an item completely may still cause issues. 