### PR TITLE
Update CheckRoyalCaribbeanPrice.py

### DIFF
--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -258,7 +258,8 @@ def getOrders(access_token,accountId,session,reservationId,passengerId,ship,star
                     continue
                 # These packages report total price, must divide by number of days
                 if prefix == "pt_beverage" or prefix == "pt_internet":
-                   paidPrice = round(paidPrice / numberOfNights,2)
+                      if not order_title.startswith("Evian") and not order_title.startswith("Specialty Coffee"):
+                          paidPrice = round(paidPrice / numberOfNights,2)
                    
                 getNewBeveragePrice(access_token,accountId,session,reservationId,ship,startDate,prefix,paidPrice,product,apobj)
 

--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -254,6 +254,8 @@ def getOrders(access_token,accountId,session,reservationId,passengerId,ship,star
                 product = orderDetail.get("productSummary").get("id")
                 prefix = orderDetail.get("productSummary").get("productTypeCategory").get("id")
                 paidPrice = orderDetail.get("guests")[0].get("priceDetails").get("subtotal")
+                if paidPrice == 0:
+                    continue
                 # These packages report total price, must divide by number of days
                 if prefix == "pt_beverage" or prefix == "pt_internet":
                    paidPrice = round(paidPrice / numberOfNights,2)


### PR DESCRIPTION
Don't pull orders with price equal to 0.  Fixes the problem for dining package reservations to be individually checked.