### PR TITLE
Mapping of reservationId to friendly display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ reservationFriendlyNames:
   '8912345': "Winter Cruise
 ```
 
+To override the system's default date format, set the dateDisplayFormat config value to your desired format:
+```
+dateDisplayFormat: "%m/%d/%Y"
+```
+
 ## Get Cruise URL (Optional)
 1. Go to Royal Caribbean or Celebrity and do a mock booking of the room you have, with the same number of adults and kids
 1. Select a cruise and Select your room type/room and complete until they ask for your personal information.

--- a/SAMPLE-config.yaml
+++ b/SAMPLE-config.yaml
@@ -10,3 +10,4 @@ apprise:  # Optional, see https://github.com/caronc/apprise, can have as many li
 reservationFriendlyNames: # Optional, only used if you want to display a name next to the reservation id
   '1234567': "Summer Cruise"
   '8912345': "Winter Cruise
+dateDisplayFormat: "%m/%d/%Y" # Optional, only needed if you want to override the system's default date display formatting


### PR DESCRIPTION
Added optional mapping of reservationId to a friendly display name, additionally change the date display to be presented a bit nicer. The date format is set as a global so it can can easily be changed if a format other than MM/DD/YYYY is desired.

Updated documentation and example config to reflect this new optional configuration mapping.