### PR TITLE
Adding Docker deployment with scheduler

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Exclude everything except what's needed for the Docker build
+*
+
+# Include only essential files
+!CheckRoyalCaribbeanPrice.py
+!requirements.txt
+!entrypoint.sh
+
+# Exclude common development files
+.git
+.gitignore
+*.md
+LICENSE
+*.spec
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.so
+.pytest_cache
+.coverage
+htmlcov/
+.DS_Store
+Thumbs.db

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,50 @@
+name: Build and Push Docker Image
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.12-alpine
 
-# No additional packages needed - busybox crond is already included in Alpine
-
 # Set working directory
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.12-alpine
+
+# No additional packages needed - busybox crond is already included in Alpine
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application files
+COPY CheckRoyalCaribbeanPrice.py .
+COPY entrypoint.sh .
+
+# Make entrypoint executable
+RUN chmod +x entrypoint.sh
+
+# Create directory for cron logs
+RUN mkdir -p /var/log
+
+# Set default environment variable for cron schedule
+ENV CRON_SCHEDULE="0 7,19 * * *"
+
+# Use our entrypoint script
+ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,38 @@ Without an account, you can also go to: `https://cruisespotlight.com/royal-carib
 1. `cd CheckRoyalCaribbeanPrice`
 1. `pip install requests Apprise bs4`
 
+## Install (Docker)
+### Option 1: Using Pre-built Image
+1. Create a `docker-compose.yml` file:
+```yaml
+services:
+  cruise-price-checker:
+    image: ghcr.io/jdeath/checkroyalcaribbeanprice:latest
+    container_name: cruise-price-checker
+    restart: unless-stopped
+    environment:
+      # Cron schedule: 7 AM and 7 PM daily (adjust as needed)
+      - CRON_SCHEDULE=0 7,19 * * *
+    volumes:
+      # Mount your config file
+      - ./config.yaml:/app/config.yaml:ro
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+```
+2. Create your `config.yaml` file (see "Edit Config File" section below)
+3. Run: `docker compose up -d`
+
+### Option 2: Build from Source
+1. Clone this repository: `git clone https://github.com/jdeath/CheckRoyalCaribbeanPrice.git`
+2. `cd CheckRoyalCaribbeanPrice`
+3. Create your `config.yaml` file (see "Edit Config File" section below)
+4. Run: `docker compose up -d`
+
+The Docker container runs the price checker on a schedule (default: 7 AM and 7 PM daily). You can customize the schedule by changing the `CRON_SCHEDULE` environment variable using standard cron format.
+
 ## Install (Not Recommended, Windows 11 Only)
 1. Download [CheckRoyalCaribbeanPrice.exe](https://github.com/jdeath/CheckRoyalCaribbeanPrice/releases/download/0.7/CheckRoyalCaribbeanPrice.exe) from releases
     -   Made with `pyinstaller -F --collect-all apprise --collect-all bs4 CheckRoyalCaribbeanPrice.py`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       # Cron schedule format: minute hour day month weekday
       # Default: 7 AM and 7 PM daily
-      - CRON_SCHEDULE=* * * * *
+      - CRON_SCHEDULE=0 7,19 * * *
     volumes:
       # Mount your config file (create config.yaml in this directory)
       - ./config.yaml:/app/config.yaml:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  cruise-price-checker:
+    build: .
+    container_name: cruise-price-checker
+    restart: unless-stopped
+    environment:
+      # Cron schedule format: minute hour day month weekday
+      # Default: 7 AM and 7 PM daily
+      - CRON_SCHEDULE=* * * * *
+    volumes:
+      # Mount your config file (create config.yaml in this directory)
+      - ./config.yaml:/app/config.yaml:ro
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Set default cron schedule if not provided
+if [ -z "$CRON_SCHEDULE" ]; then
+    CRON_SCHEDULE="0 7,19 * * *"
+fi
+
+# Create crontab with the specified schedule
+echo "$CRON_SCHEDULE cd /app && python CheckRoyalCaribbeanPrice.py >> /proc/1/fd/1 2>&1" > /etc/crontabs/root
+
+# Set permissions for crontab
+chmod 0600 /etc/crontabs/root
+
+# Start crond in foreground
+echo "Starting crond with schedule: $CRON_SCHEDULE"
+exec crond -f -d 8


### PR DESCRIPTION
## Overview
This PR aims to improve the deployment options for the price checking script by containerizing it along with a built in scheduler so there's no need to mess with any host crontabs or task managers when running the price checker.

## Summary
  - Added Docker Support, including cron scheduler for easy setup
  - Added GitHub Actions workflow for automated Docker image building and publishing to GHCR on Github release
  - Updated documentation with Docker usage instructions