### PR TITLE
Fix 403 Access Denied using browser TLS impersonation (curl_cffi)

### DIFF
--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -1,4 +1,13 @@
-import requests
+# curl_cffi impersonates a real browser's TLS fingerprint so the cruise line's
+# edge servers do not reject some IPs/systems as bots with 403 Access Denied
+# (see GitHub issue #64). Fall back to plain requests where it is not
+# installed (e.g. iOS), which works fine for most people.
+try:
+    from curl_cffi import requests
+    impersonateArgs = {"impersonate": "chrome"}
+except ImportError:
+    import requests
+    impersonateArgs = {}
 import yaml
 from datetime import datetime,date, timedelta, timezone
 from urllib.parse import urlparse, parse_qs, quote
@@ -48,6 +57,9 @@ class TimeoutSession(requests.Session):
     # Retries transient failures (connection errors, timeouts, throttling, server errors)
     # with exponential backoff so a brief API blip does not cost items until the next run.
     # After the last attempt, exceptions raise and error statuses return to the caller as before.
+    def __init__(self):
+        super().__init__(**impersonateArgs)
+
     def request(self, *args, **kwargs):
         kwargs.setdefault('timeout', REQUEST_TIMEOUT)
         for attempt in range(1, MAX_ATTEMPTS + 1):
@@ -1515,7 +1527,7 @@ def getShipDictionaryWeb():
     }
 
     try:
-        response = requests.get('https://aws-prd.api.rccl.com/en/royal/web/v2/ships', params=params, headers=headers, timeout=REQUEST_TIMEOUT)
+        response = TimeoutSession().get('https://aws-prd.api.rccl.com/en/royal/web/v2/ships', params=params, headers=headers)
     except Exception as e:
         print(f"Can't contact cruise line servers; please try again later\n(program exception '{e}')")
         sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 PyYAML
 Apprise
+curl_cffi


### PR DESCRIPTION
This implements the fix for #64 that timcreech discovered: the RCCL edge servers reject Python's default TLS fingerprint as a bot for some IPs/systems, returning 403 Access Denied even with correct browser headers. `curl_cffi` impersonating Chrome's TLS fingerprint gets past it.

### Changes
- Import `requests` from `curl_cffi` when available, and create sessions with `impersonate="chrome"`. **Falls back to plain `requests` when curl_cffi is not installed** — so iOS users (where curl_cffi cannot be installed) and any PyInstaller binaries built without it keep working exactly as today.
- Route `getShipDictionaryWeb` through `TimeoutSession` so the exact endpoint reported in the issue gets the impersonation plus the retry/backoff logic.
- Add `curl_cffi` to requirements.txt.

### Notes
- curl_cffi publishes musllinux wheels (abi3, py3.10+), so the Alpine-based Docker image installs it without needing a compiler — I checked PyPI.
- The `impersonate` kwarg is only passed when curl_cffi is actually imported, so the fallback path constructs a plain `requests.Session()` with no behavior change.
- Verified live: `getShipDictionaryWeb()` through curl_cffi returns all 47 ships, and the retry logic works unchanged on top of curl_cffi's Session.
- For the PyInstaller workflows, adding `pip install curl_cffi` to the build steps would bake the fix into the binaries; without it they simply keep the current behavior.

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
