### PR TITLE
Fix booked/watched sailings showing 'Not For Sale'

### DIFF
--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -1883,8 +1883,16 @@ def checkIfRoomIsAvailable(session,isRoyal,countryCode,packageId,sailDate,curren
             cur_categoryCode = stateroomSubtype.get("categoryCode")
             #print("Desired: " + stateroomSubtypeCode + " " + categoryCode)
             #print("Cur:     " + cur_subTypeCode + " " + categoryCode)
-            #print(f"{stateroomSubtype.get('name')} {cur_categoryCode} {cur_subTypeCode}") 
-            if cur_subTypeCode == stateroomSubtypeCode and cur_categoryCode == categoryCode:
+            #print(f"{stateroomSubtype.get('name')} {cur_categoryCode} {cur_subTypeCode}")
+            # Gate on the subtype code alone (not categoryCode). Royal's room-selection
+            # page now returns a single lead-in row per subtype: its "code" still equals the
+            # booking's stateroomSubtype, but its "categoryCode" is only the subtype's lead-in
+            # category, no longer the exhaustive per-category list. So it stops equalling the
+            # booked categoryCode for cabins booked above the lead-in (e.g. a 2D booking when
+            # the endpoint now lists 4D as the D lead-in), which made those bookings read
+            # "Not For Sale". The exact price is unaffected - the checkout POST below still
+            # uses the specific booked categoryCode.
+            if cur_subTypeCode == stateroomSubtypeCode:
                 # Need to check if rooms are left.
                 # This is not always provided, so cannot use it to check inventory
                 # roomsLeft = stateroomSubtype.get("roomsLeft",0)


### PR DESCRIPTION
Fixes booked and watched sailings reporting "Not For Sale" even though the same-category rooms are still on sale — a regression from a change on Royal's side roughly a month ago.

**Root cause**

`checkIfRoomIsAvailable` gates availability by matching the booked cabin against the `room-selection/type-and-subtype` response on **both** `code` and `categoryCode`:

```python
if cur_subTypeCode == stateroomSubtypeCode and cur_categoryCode == categoryCode:
```

Royal recently changed that endpoint to return a **single lead-in row per stateroom subtype** instead of one row per bookable category. The row's `code` still equals the booking's `stateroomSubtype`, but its `categoryCode` is now only that subtype's lead-in category — not the exhaustive per-category list. So for any cabin booked *above* the lead-in category, the `categoryCode` half of the AND-condition no longer matches and the room is wrongly reported "Not For Sale."

**Diagnosed against live bookings** (multiple ships): `code == stateroomSubtype` matched every sampled booking; `categoryCode` matched only when the booked category happened to be the subtype's lead-in. Examples where it failed:

| booking category | endpoint categoryCode (same subtype `code`) |
|---|---|
| `2D` | `4D` |
| `4H` | `2H` |

**Fix**

Gate availability on the subtype `code` alone. The precise price is unaffected — the checkout POST that follows already sends the specific booked `categoryCode`, so it still returns the fare for the exact cabin. `code` is a unique key per sailing, so there's no risk of a false match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)