### PR TITLE
Enable ANSI colors on Windows PowerShell / conhost

### DIFF
--- a/BrowseRoyalCaribbeanPrice.py
+++ b/BrowseRoyalCaribbeanPrice.py
@@ -35,6 +35,20 @@ if sys.platform == "win32":
     sys.stdout.reconfigure(encoding='utf-8', errors='replace')
     sys.stderr.reconfigure(encoding='utf-8', errors='replace')
 
+    # PowerShell 5.x / classic conhost also need virtual-terminal processing enabled or
+    # the ANSI color escapes print literally (e.g. a raw "<-[33m..."). Harmless if already
+    # on (Windows Terminal) or unsupported; failures are ignored.
+    try:
+        import ctypes
+        _kernel32 = ctypes.windll.kernel32
+        _handle = _kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
+        _mode = ctypes.c_uint32()
+        if _kernel32.GetConsoleMode(_handle, ctypes.byref(_mode)):
+            # 0x0004 = ENABLE_VIRTUAL_TERMINAL_PROCESSING
+            _kernel32.SetConsoleMode(_handle, _mode.value | 0x0004)
+    except Exception:
+        pass
+
 # Some terminals (like MobaXterm) were having trouble with printing unicode up arrow/down arrow
 # This code detects it; add to the list as more are found (if needed)
 problem_envs = ["MOBAEXTRACTONTHEFLY", "MOBANOACL"]

--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -49,6 +49,22 @@ GREEN = '\033[1;32m'
 YELLOW = '\033[33m'
 RESET = '\033[0m' # Resets color to default
 
+# Windows PowerShell 5.x and the classic console host do not interpret ANSI color
+# escapes by default, so the codes above print literally (e.g. a raw "<-[33m...").
+# Enable virtual-terminal processing on the console so they render as color. Harmless
+# where already enabled (Windows Terminal) or unsupported; failures are ignored.
+if sys.platform == "win32":
+    try:
+        import ctypes
+        _kernel32 = ctypes.windll.kernel32
+        _handle = _kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
+        _mode = ctypes.c_uint32()
+        if _kernel32.GetConsoleMode(_handle, ctypes.byref(_mode)):
+            # 0x0004 = ENABLE_VIRTUAL_TERMINAL_PROCESSING
+            _kernel32.SetConsoleMode(_handle, _mode.value | 0x0004)
+    except Exception:
+        pass
+
 dateDisplayFormat = "%x"  # Uses the locale date format unless overridden by config
 
 shipDictionary = {}


### PR DESCRIPTION
Windows PowerShell 5.x and the classic console host (conhost) don't interpret ANSI color escapes by default, so output shows raw codes instead of color — e.g. promo lines rendered as:

```
<-[33m[PROMO] UP TO 50% OFF CRUISE FAVORITES - BLACK FRIDAY (Valid ...)<-[0m
```

**Fix:** enable `ENABLE_VIRTUAL_TERMINAL_PROCESSING` on the stdout console handle via a guarded `ctypes.SetConsoleMode` call. No new dependency. It's a no-op where VT is already enabled (Windows Terminal), on non-Windows, or where the console doesn't support it (failures are swallowed).

Applied to both scripts:
- `CheckRoyalCaribbeanPrice.py` — a new module-level `sys.platform == "win32"` block by the color constants.
- `BrowseRoyalCaribbeanPrice.py` — extends the existing `win32` encoding-reconfigure block.

Confirmed live: the same PowerShell output now renders in color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)