### PR TITLE
Fix --ship matching broken by .title() ship names

### DIFF
--- a/BrowseRoyalCaribbeanPrice.py
+++ b/BrowseRoyalCaribbeanPrice.py
@@ -329,7 +329,9 @@ def get_ships_web() -> List[Dict[str, str]]:
     for ship in ships:
         ship_code = ship.get("shipCode")
         name = ship.get("name")
-        ship_names.append({'code': ship_code, 'name': name.title()})
+        # New ships arrive ALL CAPS ("HERO OF THE SEAS"); keep "of the" lowercase so
+        # the --ship matcher below ("<arg> of the Seas") still finds every ship
+        ship_names.append({'code': ship_code, 'name': (name or "").title().replace(" Of The ", " of the ")})
 
         # Hero now listed
         # HARDCODING GUARD: The server-side staging environment utilizes 'HE' for

--- a/test_price_browser.py
+++ b/test_price_browser.py
@@ -131,14 +131,17 @@ class TestWebFleetAndSailingDiscovery:
         assert ships == []
 
     @patch('BrowseRoyalCaribbeanPrice._execute_api_request')
-    def test_get_ships_web_injects_hero_of_the_seas(self, mock_execute):
-        """Verifies custom staging code mapping rule logic works correctly."""
+    def test_get_ships_web_normalizes_allcaps_names(self, mock_execute):
+        """New ships arrive from the API in ALL CAPS (e.g. HERO OF THE SEAS); names are
+        title-cased with "of the" kept lowercase so the --ship matcher ("<arg> of the
+        Seas") still finds them. The old hardcoded 'HE' injection is gone now that the
+        API lists Hero itself."""
         mock_resp = MagicMock(spec=requests.Response)
         mock_resp.json.return_value = {
             "payload": {
                 "ships": [
                     {"shipCode": "AL", "name": "Allure of the Seas"},
-                    {"shipCode": "HM", "name": "Icon Variant Staging"}
+                    {"shipCode": "HE", "name": "HERO OF THE SEAS"}
                 ]
             }
         }
@@ -146,10 +149,10 @@ class TestWebFleetAndSailingDiscovery:
 
         ships = get_ships_web()
 
-        # Verify normal code parsing combined with the special 'HE' payload insertion
-        assert len(ships) == 3
+        # No synthetic rows anymore - one output row per API ship, casing normalized
+        assert len(ships) == 2
         assert ships[0] == {'code': 'AL', 'name': 'Allure of the Seas'}
-        assert ships[2] == {'code': 'HE', 'name': 'Hero of the Seas'}
+        assert ships[1] == {'code': 'HE', 'name': 'Hero of the Seas'}
 
     @patch('BrowseRoyalCaribbeanPrice._execute_api_request')
     def test_get_sailings_web_resilient_to_malformed_json(self, mock_execute):


### PR DESCRIPTION
Follow-up to 592e7b6: `.title()` turns the ship list into `"Hero Of The Seas"`, `"Allure Of The Seas"`, etc. — but the `--ship` matcher compares literally against `f"{args.ship} of the Seas"` (lowercase "of the"), so `-s Hero`, `-s Allure`, and every other Royal `-s` value now falls through to "I can't find that ship name". The interactive menu still works, which hides the breakage.

One-line fix: normalize with `.title().replace(" Of The ", " of the ")` so the all-caps API entries (`HERO OF THE SEAS`, `CELEBRITY COMPASS`, `CELEBRITY SEEKER`) come out as `"Hero of the Seas"` — clean display *and* a working matcher. Also guards a None name.

Also updates `test_get_ships_web_injects_hero_of_the_seas`, which still pins the hardcoded `HE` injection removed in 592e7b6 (it currently fails on main), replacing it with a test of the new normalization contract. Full suite: 124 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)