### PR TITLE
Render line breaks in Apprise emails (fixes #76 one-liner emails)

### DIFF
--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -22,7 +22,10 @@ import traceback
 import time
 import yaml
 
-from apprise import Apprise
+# NotifyFormat.TEXT declares notification bodies as plain text so Apprise converts
+# them per-service: HTML email renders the \n line breaks instead of collapsing
+# them to one line (issue #76); plain-text services are passed through unchanged
+from apprise import Apprise, NotifyFormat
 from dataclasses import asdict, dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -1627,7 +1630,7 @@ def get_cruise_price(account_info: AccountInfo,
 
         # Only notify if it's a watchlist item (automatic_URL is False)
         if not automatic_URL and apobj is not None:
-            apobj.notify(body=text_string, title='Cruise Room Not Available')
+            apobj.notify(body=text_string, title='Cruise Room Not Available', body_format=NotifyFormat.TEXT)
 
         # TODO: This code block will print the "Available Rooms" line even if the count is 0;
         #       do we want to use this commented-out block instead
@@ -1672,7 +1675,7 @@ def get_cruise_price(account_info: AccountInfo,
             else:
                 log(RED + text_string + RESET)
                 if apobj is not None:
-                    apobj.notify(body=text_string, title='Cruise Price Alert')
+                    apobj.notify(body=text_string, title='Cruise Price Alert', body_format=NotifyFormat.TEXT)
 
         # Sub-branch 2: Booked drop but locked behind final lock dates
         if automatic_URL and past_final_payment_date:
@@ -1695,7 +1698,7 @@ def get_cruise_price(account_info: AccountInfo,
             else:
                 log(RED + text_string + RESET)
                 if apobj is not None:
-                    apobj.notify(body=text_string, title='Cruise Price Alert')
+                    apobj.notify(body=text_string, title='Cruise Price Alert', body_format=NotifyFormat.TEXT)
     else:
         # Current catalog price is equal to or higher than target price thresholds
         temp_string = GREEN + f"{pre_string}: You have the best price of {paid_price:.2f} {url_params.currency_code}" + RESET
@@ -2106,7 +2109,7 @@ def get_new_order_price(
         else:
             log(RED + text + RESET)
             if apobj is not None:
-                apobj.notify(body=text, title='Cruise Addon Price Alert')
+                apobj.notify(body=text, title='Cruise Addon Price Alert', body_format=NotifyFormat.TEXT)
     else:
         # Current price on server is higher than the paid price ("currently best price" path)
         if for_watch:
@@ -3479,7 +3482,7 @@ def main() -> None:
         log(f"Report generated {config.format_date(timestamp.strftime('%Y%m%d'))} {timestamp.strftime('%X')}")
 
         if config.apobj is not None and config.apprise_test:
-            config.apobj.notify(body="This is only a test. Apprise is set up correctly", title='Cruise Price Notification Test')
+            config.apobj.notify(body="This is only a test. Apprise is set up correctly", title='Cruise Price Notification Test', body_format=NotifyFormat.TEXT)
             log("Apprise Notification Sent...quitting")
             sys.exit(0)   # quit() is a site-builtin, absent in frozen builds
 
@@ -3649,6 +3652,6 @@ if __name__ == "__main__":
         if config is not None and config.notify_on_error and config.apobj:
             if len(config.apobj) > 0:
                 body = f"Script failed at {timestamp}\n{error_summary}"
-                config.apobj.notify(body=body, title='Cruise Price Script Error')
+                config.apobj.notify(body=body, title='Cruise Price Script Error', body_format=NotifyFormat.TEXT)
 
         sys.exit(1)

--- a/test_alert_matrix.py
+++ b/test_alert_matrix.py
@@ -184,6 +184,10 @@ class TestCruiseFareAlerts:
         body = apobj.notify.call_args.kwargs["body"]
         assert "Rebook!" in body
         assert "2500.00" in body and "3000.00" in body
+        # Bodies are declared plain text so Apprise converts \n per-service
+        # (HTML email would otherwise collapse them to one line - issue #76)
+        from apprise import NotifyFormat
+        assert apobj.notify.call_args.kwargs.get("body_format") == NotifyFormat.TEXT
 
     def test_equal_price_stays_silent(self):
         apobj, logged = run_cruise_scenario(results={**AVAILABLE, "base_fare": fare(3000.0)}, paid=3000.0)


### PR DESCRIPTION
Addresses #76: add-on alert emails arrive as one long line for some users. The cause is that Apprise's email plugin sends HTML-format email by default, and the literal `\n` breaks already present in the alert bodies collapse in HTML.

Fix: pass `body_format=NotifyFormat.TEXT` on all six `notify()` calls. This declares the body as plain text and Apprise converts it per-service — HTML email renders real line breaks, while ntfy/Telegram/other plain-text services receive exactly what they do today. No alert body strings are changed, so notification content is untouched (the alert-contract tests in test_alert_matrix.py pass unmodified, with one new assertion pinning the format flag).

Aside for anyone who wants plain-text emails outright: appending `?format=text` to a `mailto://` URL in config.yaml achieves that per-URL with no code change.

@dstein766's fuller multi-line email layout from #76 would layer cleanly on top of this if wanted — this PR is just the minimal universal fix.

Note: the one failing test on this branch (`test_get_ships_web_injects_hero_of_the_seas`) is pre-existing on main and fixed separately by #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)