### PR TITLE
Make apprise optional again (fixes #85)

### DIFF
--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -22,7 +22,14 @@ import traceback
 import time
 import yaml
 
-from apprise import Apprise
+# Apprise is optional (e.g. the iOS full install runs without it): when the
+# package is missing, notifications are disabled and everything else works
+# normally. apobj is only ever constructed when the import succeeded.
+try:
+    from apprise import Apprise, NotifyFormat
+except ImportError:
+    Apprise = None
+    NotifyFormat = None
 from dataclasses import asdict, dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -3308,9 +3315,12 @@ def load_config_objects(config_path: str) -> CruiseAppConfig:
     # Parse Apprise URLs safely
     apprise_urls = [item["url"] for item in data.get("apprise", []) if "url" in item]
 
-    # Build the apprise object natively
+    # Build the apprise object natively (apprise is an optional dependency)
     apobj = None
-    if apprise_urls:
+    if apprise_urls and Apprise is None:
+        logging.warning("apprise: is configured in config.yaml but the apprise package "
+                        "is not installed - notifications are disabled. pip install apprise")
+    elif apprise_urls:
         apobj = Apprise()
         for url in apprise_urls:
             apobj.add(url)

--- a/test_price_checker.py
+++ b/test_price_checker.py
@@ -2369,3 +2369,23 @@ def test_timeout_retry_constants():
     assert crccl.RETRY_BACKOFF_BASE == 2
     assert crccl.DEFAULT_ON_FAILURE == "retry"
     assert crccl.ACCOUNT_COOLDOWN_SECONDS == 5
+
+
+def test_config_parses_without_apprise_package(tmp_path, monkeypatch):
+    """apprise is an optional dependency: a config with an apprise: block must
+    still parse when the package is absent - notifications just turn off."""
+    import CheckRoyalCaribbeanPrice as crccl
+    monkeypatch.setattr(crccl, "Apprise", None)
+    yaml_content = """
+    accountInfo:
+      - username: "test_user"
+        password: "password123"
+    apprise:
+      - url: "mailto://user:password@example.com"
+    """
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml_content)
+    with patch('CheckRoyalCaribbeanPrice.setup_hybrid_logging'):
+        config = load_config_objects(str(config_file))
+    assert config.apobj is None                    # disabled, not crashed
+    assert config.accounts[0].username == "test_user"


### PR DESCRIPTION
Fixes #85: before 3.4.1, apprise was imported lazily only when `apprise:` was configured, so the script ran fine without the package (the documented iOS "full version, everything except apprise" install relies on this). The refactor introduced an unguarded module-top `from apprise import Apprise`, which crashes at startup when the package is missing.

This restores the optional behavior in the refactor's own style — the same pattern as the optional curl_cffi import at the top of the file:

- the apprise import is wrapped in try/except, leaving `Apprise`/`NotifyFormat` as `None` when absent
- if `apprise:` IS configured but the package is missing, the config parser logs a clear warning ("notifications are disabled - pip install apprise") instead of crashing
- all `notify()` calls already sit behind `apobj is not None`, and `apobj` can only be constructed when the import succeeded, so no other changes are needed (`from __future__ import annotations` keeps the `Optional[Apprise]` type hints safe as strings)

Verified end-to-end by importing the module with apprise absence simulated: imports cleanly with `Apprise = None`. Adds a test that a config containing an `apprise:` block still parses without the package.

Notes: the import guard includes `NotifyFormat` so this composes with #83 in either merge order (whichever lands second is a trivial line conflict — happy to rebase). The one failing test on this branch (`test_get_ships_web_injects_hero_of_the_seas`) is pre-existing on main and fixed by #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)