### PR TITLE
Harden the #88/#85 fixes: plain-requests fallback + apprise sentinels

### DIFF
--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -15,10 +15,15 @@ import re
 try:
     from curl_cffi import requests
     impersonate_args = {"impersonate": "chrome"}
+    # Plain requests kept alongside for the few endpoints that misbehave under
+    # curl_cffi on some networks (room availability, issue #88)
     import requests as requests_normal
 except ImportError:
     import requests
     impersonate_args = {}
+    # Without curl_cffi, plain requests IS the only engine - alias it so the
+    # requests_normal call sites work instead of raising NameError
+    requests_normal = requests
 
 import sys
 import traceback
@@ -28,11 +33,16 @@ import yaml
 # NotifyFormat.TEXT declares notification bodies as plain text so Apprise converts
 # them per-service: HTML email renders the \n line breaks instead of collapsing
 # them to one line (issue #76); plain-text services are passed through unchanged
+# Apprise is optional (e.g. the iOS full install runs without it). The None
+# sentinels matter: the config parser checks "Apprise is None" to warn-and-disable
+# when apprise: is configured without the package - a bare "except: pass" leaves
+# the names undefined and turns that check into a NameError crash (issue #85).
 try:
     from apprise import Apprise, NotifyFormat
-except:
-    pass
-    
+except ImportError:
+    Apprise = None
+    NotifyFormat = None
+
 from dataclasses import asdict, dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Set, Tuple, Union

--- a/test_price_checker.py
+++ b/test_price_checker.py
@@ -1503,7 +1503,7 @@ def test_check_if_room_is_available_network_exception_tolerance():
     url_params.cabin_class_string = "BALCONY"
 
     # Simulate a sudden socket/connection reset drop during validation loops
-    with patch('CheckRoyalCaribbeanPrice.requests.get', side_effect=requests.exceptions.ConnectionError("Connection reset by peer")):
+    with patch('CheckRoyalCaribbeanPrice.requests_normal.get', side_effect=requests.exceptions.ConnectionError("Connection reset by peer")):
         try:
             available, alternate_rooms = check_if_room_is_available(url_params)
             assert available is False
@@ -2169,7 +2169,7 @@ def test_availability_matches_on_subtype_code_even_when_category_differs():
     params = _availability_params(subtype="D", category_code="2D")  # booked above the lead-in
     mock_resp = MagicMock()
     mock_resp.text = _room_selection_rsc(code="D", category_code="4D")
-    with patch('CheckRoyalCaribbeanPrice.requests.get', return_value=mock_resp):
+    with patch('CheckRoyalCaribbeanPrice.requests_normal.get', return_value=mock_resp):
         available, alternates = check_if_room_is_available(params)
     assert available is True
     assert alternates == []
@@ -2180,7 +2180,7 @@ def test_availability_false_when_subtype_code_absent():
     params = _availability_params(subtype="Z", category_code="9Z")
     mock_resp = MagicMock()
     mock_resp.text = _room_selection_rsc(code="D", category_code="4D")
-    with patch('CheckRoyalCaribbeanPrice.requests.get', return_value=mock_resp):
+    with patch('CheckRoyalCaribbeanPrice.requests_normal.get', return_value=mock_resp):
         available, alternates = check_if_room_is_available(params)
     assert available is False
     assert len(alternates) == 1


### PR DESCRIPTION
Follow-ups to 4dbc2b5 addressing the loose ends on #88 and #85 — your `requests_normal` approach is kept (it's the behavior you verified on the affected Windows/Docker machines); this PR fixes the two holes in it plus the apprise guard.

**#88 (`requests_normal`):**
- Without curl_cffi installed, `requests_normal` was never defined (it only exists in the `try` branch), so `check_if_room_is_available` raised `NameError` — silently caught as "Unable to check room availability" — and every watchlist cruise showed Not For Sale for plain-requests installs (iOS included). The fallback branch now aliases `requests_normal = requests`, so plain-requests users get exactly the engine that works for them.
- The two unit-test failures you posted were because the tests patch `CheckRoyalCaribbeanPrice.requests.get` while the code now calls `requests_normal.get` — under curl_cffi the mocks missed and the tests hit the live network. The three availability tests now patch `requests_normal.get`, so they're deterministic in both environments. Full suite: 149 passed.

For the record, I tried to reproduce the underlying curl_cffi failure from here using your test URL: from my network the type-and-subtype endpoint returns the rooms array both with and without impersonation, so the Akamai behavior looks IP/environment-dependent — your plain-requests route is the pragmatic call. If it ever breaks the other way, `requests.get(..., **impersonate_args)` (browser TLS impersonation, the pattern Browse's shared engine uses) is the alternative worth trying on an affected machine.

**#85 (apprise, re @klemmerm's comment):** the bare `except: pass` guard leaves `Apprise`/`NotifyFormat` undefined when the package is missing, so the config parser's `Apprise is None` warn-and-disable check becomes a NameError crash for anyone with an `apprise:` block in config.yaml and no package installed. Restored the `None` sentinels from #86: missing package now logs "notifications are disabled - pip install apprise" and runs on. Verified end-to-end by importing with apprise absence simulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)