### PR TITLE
Robustness enhancements for curl_cffi cabin watchlist issue #88

### DIFF
--- a/BrowseRoyalCaribbeanPrice.py
+++ b/BrowseRoyalCaribbeanPrice.py
@@ -11,14 +11,16 @@ import time
 
 # curl_cffi impersonates a real browser's TLS fingerprint so the cruise line's
 # edge servers do not reject some IPs/systems as bots with 403 Access Denied
-# (see jdeath/CheckRoyalCaribbeanPrice issue #64, where the Browse script was
-# confirmed affected). Fall back to plain requests where it is not installed
-# (e.g. iOS), which works fine for most people.
+# (see jdeath/CheckRoyalCaribbeanPrice issue #64). Fall back to plain requests
+# where it is not installed (e.g. iOS), which works fine for most people.
+# Keep standard requests available alongside curl_cffi for endpoints that
+# misbehave under TLS impersonation/headers on some networks (e.g. issue #88)
+import requests as plain_requests
 try:
     from curl_cffi import requests
     IMPERSONATE_ARGS = {"impersonate": "chrome"}
 except ImportError:
-    import requests
+    requests = plain_requests
     IMPERSONATE_ARGS = {}
 
 from datetime import datetime, date
@@ -168,9 +170,20 @@ class StripAnsiFilter(logging.Filter):
 ##################################
 # Helper functions
 ##################################
+def new_api_session(use_impersonation: bool = True) -> plain_requests.Session:
+    """
+    Creates a network session that impersonates a real browser's TLS fingerprint
+    when curl_cffi is available and requested, falling back to standard requests.
+    """
+    if use_impersonation and IMPERSONATE_ARGS:
+        return requests.Session(**IMPERSONATE_ARGS)
+    return plain_requests.Session()
+
+
 def _execute_api_request(
-    method: str,
-    url: str,
+    account_info: Optional[AccountInfo] = None,
+    method: str = "GET",
+    url: str = "",
     params: Optional[dict] = None,
     data: Optional[Union[str, dict]] = None,
     json_data: Optional[dict] = None,
@@ -178,37 +191,52 @@ def _execute_api_request(
     timeout: Optional[int] = None,
     on_failure: str = DEFAULT_ON_FAILURE,
     exit_on_fail: Optional[bool] = None,
-    max_retries: int = MAX_RETRIES
-) -> Optional[requests.Response]:
+    max_retries: int = MAX_RETRIES,
+    use_impersonation: bool = True
+) -> Optional[plain_requests.Response]:
     """
     Unified API execution engine for all cruise line network interactions.
 
     Centralizes tracking parameters, developer keys, and connect timeouts.
+    If an active session profile exists, it automatically injects 'Access-Token'
+    and account tracking headers into the request context.
 
     Supported strategies for on_failure:
     - "retry": Automatically retries transient errors with exponential backoff.
     - "skip" : Logs the warning and returns None on failure.
     - "exit" : Logs the error and terminates the script entirely on failure.
     """
-    # Backwards compatibility helper for existing exit_on_fail parameters
+    # Backwards compatibility helper for existing exit_on_fail parameter callers
     if exit_on_fail is not None:
         on_failure = "exit" if exit_on_fail else "skip"
 
+    # Resolve effective timeout: explicit override -> config setting -> default baseline
     if timeout is None:
-        timeout = REQUEST_TIMEOUT  # Default baseline timeout (e.g., 30s)
+        timeout = getattr(config, "request_timeout", REQUEST_TIMEOUT) if 'config' in globals() else REQUEST_TIMEOUT
 
-    # Start with any caller-specified override headers, or an empty base
+    # Start with caller override headers or an empty dictionary
     final_headers = headers.copy() if headers else {}
 
-    # Always include the baseline developer web key
+    # Inject corporate authentication layers if a live session exists
+    if account_info and getattr(account_info, "access", None):
+        if "Access-Token" not in final_headers and account_info.access.token:
+            final_headers["Access-Token"] = account_info.access.token
+        if "vds-id" not in final_headers and account_info.access.id:
+            final_headers["vds-id"] = account_info.access.id
+        if "account-id" not in final_headers and account_info.access.id:
+            final_headers["account-id"] = account_info.access.id
+
+    # Always include baseline developer web key
     if "AppKey" not in final_headers and "appkey" not in final_headers:
         final_headers["AppKey"] = APPKEY_WEB
 
-    # Create a network session that impersonates a real browser's TLS fingerprint
-    # when curl_cffi is available, falling back to a standard requests session.
-    session_context = requests.Session(**IMPERSONATE_ARGS)
+    # Target session selection: existing session token or new engine session
+    if account_info and getattr(account_info, "access", None) and account_info.access.session:
+        session_context = account_info.access.session
+    else:
+        session_context = new_api_session(use_impersonation=use_impersonation)
 
-    def _handle_terminal_failure(error: Exception) -> Optional[requests.Response]:
+    def _handle_terminal_failure(error: Exception) -> Optional[plain_requests.Response]:
         error_msg = f"Can't contact cruise line servers; please try again later\n(program exception '{error}')"
         if on_failure == "exit":
             log(error_msg)
@@ -231,15 +259,17 @@ def _execute_api_request(
                     timeout=timeout
                 )
 
-                # Treat server errors (5xx) as retriable exceptions
+                # Treat 5xx server errors as transient retriable errors
                 if response.status_code >= 500:
-                    raise requests.exceptions.HTTPError(f"Server Error {response.status_code}", response=response)
+                    raise plain_requests.exceptions.HTTPError(
+                        f"Server Error {response.status_code}", response=response
+                    )
 
                 response.raise_for_status()
                 return response  # Success!
 
             except Exception as e:
-                # Terminal 4xx client errors should fail immediately without retrying
+                # Terminal 4xx client errors (e.g. 401, 403, 404) fail fast without retrying
                 resp_obj = getattr(e, "response", None)
                 status_code = getattr(resp_obj, "status_code", None)
                 if status_code and 400 <= status_code < 500:

--- a/BrowseRoyalCaribbeanPrice.py
+++ b/BrowseRoyalCaribbeanPrice.py
@@ -272,6 +272,13 @@ def _execute_api_request(
                 # Terminal 4xx client errors (e.g. 401, 403, 404) fail fast without retrying
                 resp_obj = getattr(e, "response", None)
                 status_code = getattr(resp_obj, "status_code", None)
+                # Fallback: curl_cffi's HTTPError does not always attach .response -
+                # parse the status out of the exception text ("404 Not Found") so a
+                # definitive client error is never misread as transient and retried
+                if status_code is None:
+                    match = re.search(r"\b([45]\d\d)\b", str(e))
+                    if match:
+                        status_code = int(match.group(1))
                 if status_code and 400 <= status_code < 500:
                     return _handle_terminal_failure(e)
 

--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -652,6 +652,13 @@ def _execute_api_request(
                 # Terminal 4xx client errors (e.g. 401, 403, 404) fail fast without retrying
                 resp_obj = getattr(e, "response", None)
                 status_code = getattr(resp_obj, "status_code", None)
+                # Fallback: curl_cffi's HTTPError does not always attach .response -
+                # parse the status out of the exception text ("404 Not Found") so a
+                # definitive client error is never misread as transient and retried
+                if status_code is None:
+                    match = re.search(r"\b([45]\d\d)\b", str(e))
+                    if match:
+                        status_code = int(match.group(1))
                 if status_code and 400 <= status_code < 500:
                     return _handle_terminal_failure(e)
 

--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -12,12 +12,15 @@ import re
 # edge servers do not reject some IPs/systems as bots with 403 Access Denied
 # (see jdeath/CheckRoyalCaribbeanPrice issue #64). Fall back to plain requests
 # where it is not installed (e.g. iOS), which works fine for most people.
+# Keep standard requests available alongside curl_cffi for endpoints that
+# misbehave under TLS impersonation/headers on some networks (e.g. issue #88)
+import requests as plain_requests
 try:
     from curl_cffi import requests
-    impersonate_args = {"impersonate": "chrome"}
+    IMPERSONATE_ARGS = {"impersonate": "chrome"}
 except ImportError:
-    import requests
-    impersonate_args = {}
+    requests = plain_requests
+    IMPERSONATE_ARGS = {}
 
 import sys
 import traceback
@@ -538,25 +541,30 @@ class CruiseAppConfig:
 ############################################
 # Low-level Network Engine & Data Harvesters
 ############################################
-def new_api_session() -> requests.Session:
+def new_api_session(use_impersonation: bool = True) -> plain_requests.Session:
     """
     Creates a network session that impersonates a real browser's TLS fingerprint
-    when curl_cffi is available, falling back to a standard requests session.
+    when curl_cffi is available and requested, falling back to standard requests.
     """
-    return requests.Session(**impersonate_args)
+    if use_impersonation and IMPERSONATE_ARGS:
+        return requests.Session(**IMPERSONATE_ARGS)
+    return plain_requests.Session()
 
 
 def _execute_api_request(
-    account_info: Optional[AccountInfo],
-    method: str,
-    url: str,
+    account_info: Optional[AccountInfo] = None,
+    method: str = "GET",
+    url: str = "",
     params: Optional[dict] = None,
     data: Optional[Union[str, dict]] = None,
+    json_data: Optional[dict] = None,
     headers: Optional[dict] = None,
     timeout: Optional[int] = None,
     on_failure: str = DEFAULT_ON_FAILURE,
-    max_retries: int = MAX_RETRIES
-) -> Optional[requests.Response]:
+    exit_on_fail: Optional[bool] = None,
+    max_retries: int = MAX_RETRIES,
+    use_impersonation: bool = True
+) -> Optional[plain_requests.Response]:
     """
     Unified API execution engine for all cruise line network interactions.
 
@@ -566,19 +574,22 @@ def _execute_api_request(
 
     Supported strategies for on_failure:
     - "retry": Automatically retries transient errors with exponential backoff.
-    - "skip" : Logs the warning and returns None.
-    - "exit" : Logs the error and terminates the script entirely.
+    - "skip" : Logs the warning and returns None on failure.
+    - "exit" : Logs the error and terminates the script entirely on failure.
     """
-    # Resolve the effective timeout: an explicit caller override wins, then the
-    # user-configured requestTimeout, then the 30-second baseline default
-    if timeout is None:
-        timeout = config.request_timeout if config else REQUEST_TIMEOUT
+    # Backwards compatibility helper for existing exit_on_fail parameter callers
+    if exit_on_fail is not None:
+        on_failure = "exit" if exit_on_fail else "skip"
 
-    # Start with any caller-specified override headers, or an empty base
+    # Resolve effective timeout: explicit override -> config setting -> default baseline
+    if timeout is None:
+        timeout = getattr(config, "request_timeout", REQUEST_TIMEOUT) if 'config' in globals() else REQUEST_TIMEOUT
+
+    # Start with caller override headers or an empty dictionary
     final_headers = headers.copy() if headers else {}
 
     # Inject corporate authentication layers if a live session exists
-    if account_info and account_info.access:
+    if account_info and getattr(account_info, "access", None):
         if "Access-Token" not in final_headers and account_info.access.token:
             final_headers["Access-Token"] = account_info.access.token
         if "vds-id" not in final_headers and account_info.access.id:
@@ -586,12 +597,24 @@ def _execute_api_request(
         if "account-id" not in final_headers and account_info.access.id:
             final_headers["account-id"] = account_info.access.id
 
-    # Always include the baseline developer key
-    if "AppKey" not in final_headers:
+    # Always include baseline developer web key
+    if "AppKey" not in final_headers and "appkey" not in final_headers:
         final_headers["AppKey"] = APPKEY_WEB
 
-    # Choose the target network session channel
-    session_context = account_info.access.session if (account_info and account_info.access) else new_api_session()
+    # Target session selection: existing session token or new engine session
+    if account_info and getattr(account_info, "access", None) and account_info.access.session:
+        session_context = account_info.access.session
+    else:
+        session_context = new_api_session(use_impersonation=use_impersonation)
+
+    def _handle_terminal_failure(error: Exception) -> Optional[plain_requests.Response]:
+        error_msg = f"Can't contact cruise line servers; please try again later\n(program exception '{error}')"
+        if on_failure == "exit":
+            log(error_msg)
+            sys.exit(1)
+        else:
+            logging.warning(f"Non-critical API interaction skipped (exception: {error})")
+            return None
 
     # --- STRATEGY A: RESILIENT RETRY LOOP ---
     if on_failure == "retry":
@@ -602,19 +625,34 @@ def _execute_api_request(
                     url=url,
                     params=params,
                     data=data,
+                    json=json_data,
                     headers=final_headers,
                     timeout=timeout
                 )
+
+                # Treat 5xx server errors as transient retriable errors
+                if response.status_code >= 500:
+                    raise plain_requests.exceptions.HTTPError(
+                        f"Server Error {response.status_code}", response=response
+                    )
+
                 response.raise_for_status()
                 return response  # Success!
+
             except Exception as e:
+                # Terminal 4xx client errors (e.g. 401, 403, 404) fail fast without retrying
+                resp_obj = getattr(e, "response", None)
+                status_code = getattr(resp_obj, "status_code", None)
+                if status_code and 400 <= status_code < 500:
+                    return _handle_terminal_failure(e)
+
                 if attempt < max_retries:
                     backoff_time = RETRY_BACKOFF_BASE ** attempt
                     logging.warning(f"Attempt {attempt}/{max_retries} failed for {url}: {e}. Retrying in {backoff_time}s...")
                     time.sleep(backoff_time)
                 else:
-                    logging.warning(f"All {max_retries} retry attempts exhausted for {url}. Falling back to 'skip' safety.")
-                    return None
+                    logging.warning(f"All {max_retries} retry attempts exhausted for {url}.")
+                    return _handle_terminal_failure(e)
 
     # --- STRATEGY B: STATIC SINGLE-SHOT ACTIONS ("skip" or "exit") ---
     try:
@@ -623,21 +661,14 @@ def _execute_api_request(
             url=url,
             params=params,
             data=data,
+            json=json_data,
             headers=final_headers,
             timeout=timeout
         )
         response.raise_for_status()
         return response
     except Exception as e:
-        error_msg = f"Can't contact cruise line servers; please try again later\n(program exception '{e}')"
-
-        if on_failure == "exit":
-            log(error_msg)
-            sys.exit(1)
-        else:
-            # Matches legacy exit_on_fail=False behavior
-            logging.warning(f"Non-critical API interaction skipped (exception: {e})")
-            return None
+        return _handle_terminal_failure(e)
 
 
 def _extract_json_array(text: str, key: str) -> Optional[list[Any]]:
@@ -1233,10 +1264,10 @@ def get_voyages(account_info: AccountInfo, discounts: CruiseURLParams, ship_dict
         insurance_flag = False
         all_included_flag = False
         cruise_paid_price_from_API = result.get("prices", [])
-        
+
         final_payment_date = get_final_payment_date(number_of_nights, sail_date)
         final_payment_date_display = final_payment_date.strftime(date_display_format)
-        
+
         for cur_price in cruise_paid_price_from_API:
             price_type_code = cur_price.get("priceTypeCode", "")
             amount = cur_price.get("amount")
@@ -1268,7 +1299,7 @@ def get_voyages(account_info: AccountInfo, discounts: CruiseURLParams, ship_dict
             paid_price_struct['all_in_upgrade'] = all_included_flag
             log(f"Cruise Fare - Total {gross_totals:.2f}{payment_string}")
 
-        
+
 
         # Record this booking for the end-of-run check-in / final-payment summary table.
         # Include the room number so multiple cabins on the same sailing are distinct.
@@ -1900,16 +1931,19 @@ def check_if_room_is_available(params: CruiseURLParams) -> tuple[bool, List[Dict
         'r0C': 'y',
     }
 
-    # TODO: Migrate to _execute_api_request() with on_failure="retry".
-    # This loop lookup is an excellent candidate for our new exponential backoff
-    # engine, but is left single-shot for this PR to keep the price-tracking loop
-    # scope completely isolated and test-stabilized.
     api_URL = f'https://www.{params.url_brand}.com/room-selection/type-and-subtype'
-    try:
-        response = requests.get(api_URL, params=request_params, headers=headers,
-                                timeout=config.request_timeout if config else REQUEST_TIMEOUT)
-    except Exception as err:
-        log (f"Unable to check room availability with server ({err})")
+    response = _execute_api_request(
+        method="GET",
+        url=api_URL,
+        params=request_params,
+        headers=headers,
+        timeout=config.request_timeout if config else REQUEST_TIMEOUT,
+        on_failure="skip",
+        use_impersonation=False
+    )
+
+    if response is None:
+        log("Unable to check room availability with server")
         return False, []
 
     # Extract structural array matrix out of the component text stream

--- a/test_price_browser.py
+++ b/test_price_browser.py
@@ -8,9 +8,9 @@ from unittest.mock import patch, MagicMock
 # Import targets from module
 from BrowseRoyalCaribbeanPrice import (
     _execute_api_request,
-    get_all_activities_web,           # or get_schedulable_products_web depending on your alias
+    get_all_activities_web,
     get_cruise_price_from_API,
-    get_MDR_locations,    # or get_dining_venues_graph depending on your alias
+    get_MDR_locations,
     get_products_graph_all_pages,
     get_ships_web,
     get_sailing_details_web,

--- a/test_price_checker.py
+++ b/test_price_checker.py
@@ -950,75 +950,6 @@ def test_parse_granular_checkin_per_passenger(mock_booking_with_dining_and_check
 
     def api_router(*args, **kwargs):
         url_called = args[2] if len(args) > 2 else kwargs.get("url", "")
-        if "promotions/list" in url_called:
-            return MagicMock(json=lambda: mock_promo_response)
-        elif "orderHistory" in url_called:
-            return MagicMock(json=lambda: mock_order_response)
-        else:
-            return MagicMock(json=lambda: mock_bookings_response)
-
-    checkin_logs = []
-    for guest in mock_booking_with_dining_and_checkin["guests"]:
-        name = guest["firstName"]
-        status = guest["checkInStatus"]
-        b_time = guest["boardingTime"].replace(" PM", "").strip()
-        checkin_logs.append(f"{name} Check in {status}, Boarding Time {b_time}")
-
-    mock_metrics = {
-        "passenger_names": "Bob, Matt",
-        "checkin_string": ", ".join(checkin_logs)
-    }
-
-    mock_dining_and_prices = {
-        "dining_selection": [{"sittingType": "TRADITIONAL", "sittingTime": "05:00 PM", "tableSize": "04"}],
-        "prices": [{"priceTypeCode": "GROSS_TOTALS", "amount": 2662.96}]
-    }
-
-    with patch('CheckRoyalCaribbeanPrice._execute_api_request', side_effect=api_router), \
-         patch('CheckRoyalCaribbeanPrice._calculate_passenger_metrics', return_value=mock_metrics), \
-         patch('CheckRoyalCaribbeanPrice.get_dining_and_prices', return_value=mock_dining_and_prices), \
-         patch('CheckRoyalCaribbeanPrice.get_checkin_info'), \
-         patch('CheckRoyalCaribbeanPrice.log') as mock_log:
-
-        get_voyages(account_info, discounts, ship_registry)
-
-        log_outputs = [call[0][0] for call in mock_log.call_args_list]
-        assert any("Bob Check in Partially Complete, Boarding Time 12:00" in s for s in log_outputs), \
-            "Granular passenger check-in layout contract was missed!"
-
-# =====================================================================
-# ITEM 6 FOUNDATIONAL TESTS: Low-level Network & Helper Verification
-# =====================================================================
-def test_parse_granular_checkin_per_passenger(mock_booking_with_dining_and_checkin):
-    """
-    Verify that individual passenger check-in statuses and boarding constraints
-    are clearly enumerated inside the log stream.
-    """
-    account_info = AccountInfo(username="test_user", password="password", cruise_line="royal")
-    account_info.access = MagicMock()
-
-    discounts = CruiseURLParams(loyalty_number="390323599", state="FL", dp340=False)
-    ship_registry = ShipRegistry()
-
-    mock_bookings_response = {
-        "payload": {
-            "profileBookings": [{
-                "bookingId": "9999999",
-                "passengerId": "33333333",
-                "sailDate": "20270510",
-                "numberOfNights": 7,
-                "shipCode": "WN",
-                "stateroomNumber": "6574",
-                "stateroomType": "B",
-                "passengersInStateroom": [{"firstName": "Matt", "lastName": "Smith", "bookingId": "9999999"}]
-            }]
-        }
-    }
-    mock_promo_response = {"payload": []}
-    mock_order_response = {"payload": []}
-
-    def api_router(*args, **kwargs):
-        url_called = args[2] if len(args) > 2 else kwargs.get("url", "")
 
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -1062,6 +993,35 @@ def test_parse_granular_checkin_per_passenger(mock_booking_with_dining_and_check
         log_outputs = [call[0][0] for call in mock_log.call_args_list]
         assert any("Bob Check in Partially Complete, Boarding Time 12:00" in s for s in log_outputs), \
             "Granular passenger check-in layout contract was missed!"
+
+
+# =====================================================================
+# ITEM 6 FOUNDATIONAL TESTS: Low-level Network & Helper Verification
+# =====================================================================
+def test_execute_api_request_handles_uninitialized_access_context():
+    """
+    Ensure the network engine falls back cleanly to a fresh session
+    if account_info is passed but access configurations are missing.
+    """
+    # Create an AccountInfo model wrapper where access profile is explicit None
+    account_info = AccountInfo(username="tester", password="password", cruise_line="royal")
+    account_info.access = None
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status.return_value = None
+
+    # No usable account session -> the engine builds one via new_api_session();
+    # patch both engines' Session.request so the test holds with or without curl_cffi
+    with patch('CheckRoyalCaribbeanPrice.plain_requests.Session.request', return_value=mock_response), \
+         patch('CheckRoyalCaribbeanPrice.requests.Session.request', return_value=mock_response) as mock_req:
+        resp = _execute_api_request(
+            account_info=account_info,
+            method="GET",
+            url="https://aws-prd.api.rccl.com/test-endpoint",
+            on_failure="retry"
+        )
+        assert resp is not None
 
 
 @patch("time.sleep", return_value=None)  # Fast execution warp drive
@@ -1553,9 +1513,12 @@ def test_check_if_room_is_available_network_exception_tolerance():
     url_params.package_code = "SY07W115"
     url_params.cabin_class_string = "BALCONY"
 
-    # Simulate a sudden socket/connection reset drop during validation loops
+    # Simulate a sudden socket/connection reset drop during validation loops.
+    # The availability call runs through _execute_api_request with a plain
+    # (non-impersonated) session, so patch that engine's Session.request -
+    # patching requests.get would miss and the test would hit the live network.
     with patch(
-        'CheckRoyalCaribbeanPrice.requests.get',
+        'CheckRoyalCaribbeanPrice.plain_requests.Session.request',
         side_effect=requests.exceptions.ConnectionError("Connection reset by peer")
     ):
         try:

--- a/test_price_checker.py
+++ b/test_price_checker.py
@@ -1554,7 +1554,10 @@ def test_check_if_room_is_available_network_exception_tolerance():
     url_params.cabin_class_string = "BALCONY"
 
     # Simulate a sudden socket/connection reset drop during validation loops
-    with patch('CheckRoyalCaribbeanPrice.requests_normal.get', side_effect=requests.exceptions.ConnectionError("Connection reset by peer")):
+    with patch(
+        'CheckRoyalCaribbeanPrice.requests.get',
+        side_effect=requests.exceptions.ConnectionError("Connection reset by peer")
+    ):
         try:
             available, alternate_rooms = check_if_room_is_available(url_params)
             assert available is False

--- a/test_price_checker.py
+++ b/test_price_checker.py
@@ -22,8 +22,12 @@ from CheckRoyalCaribbeanPrice import (
 # ITEM 12 EXTRA ADD-ON ENGINE TESTS: Cost Metrics & Promotion Boundaries
 # ITEM 13 EXTRA METRIC CALCULATION TESTS: Scope Isolation & String Resiliency
 # ITEM 14 ORCHESTRATION & RUN CONTROL TESTS: Configuration Lifecycle
-# ITEM 15: PARTIAL CHECK-IN & DP340 DISCOUNT FORWARDING VALIDATION
-# ITEM 16 EXTRA REFACTOR & WATCHLIST ROUTING FIXES
+# ITEM 15 PARTIAL CHECK-IN & DP340 DISCOUNT FORWARDING VALIDATION TESTS
+# ITEM 16 EXTRA REFACTOR & WATCHLIST ROUTING FIX TESTS
+# ITEM 17 "NOT FOR SALE" AVAILABILITY GATE (MATCH ON SUBTYPE CODE ALONE) TESTS
+# ITEM 18 END-OF-RUN CHECK-IN & FINAL-PAYMENT SUMMARY TABLE TESTS
+# ITEM 19 PAYMENT TABLE BALANCE-DUE TRI-STATE TESTS
+# ITEM 20 API TIMEOUT / RETRY CONSTANTS TEST
     AccountInfo,
     APIAccess,
     CruiseAppConfig,
@@ -83,6 +87,7 @@ def mock_global_config():
     # Restore original state after test run
     CheckRoyalCaribbeanPrice.config = original_config
 
+
 @pytest.fixture
 def base_account_info():
     """Generates a standard authenticated user runtime context template with fake network access."""
@@ -100,6 +105,7 @@ def base_account_info():
     account.access = mock_access
     account.found_items = set()
     return account
+
 
 # Setup a dummy minimal global config to satisfy formatting calls
 @pytest.fixture()
@@ -721,25 +727,15 @@ def test_get_voyages_complete_execution_path():
     discounts = CruiseURLParams(loyalty_number="123456", state="MD", dp340=False)
     ship_registry = ShipRegistry()
 
-    # Mock full corporate server structure response for profileBookings
-    mock_bookings_response = MagicMock()
-    mock_bookings_response.json.return_value = {
-        "payload": {
-            "profileBookings": [{
-                "bookingId": "1234567",
-                "passengerId": "33333333",
-                "sailDate": "20261225",
-                "numberOfNights": 7,
-                "shipCode": "AL",
-                "stateroomNumber": "6543",
-                "stateroomType": "B",
-                "passengersInStateroom": [{"firstName": "Matt", "lastName": "Smith", "bookingId": "1234567"}]
-            }]
-        }
-    }
-
-    def mock_api_router(account_info, method, url, *args, **kwargs):
+    # Router handling positional/keyword variations safely
+    def mock_api_router(*args, **kwargs):
         mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = '{"rooms": []}'
+
+        # Safely extract URL regardless of how positional/keyword args are passed
+        url = args[2] if len(args) > 2 else kwargs.get("url", "")
+
         if "profileBookings" in url:
             mock_resp.json.return_value = {
                 "payload": {
@@ -766,6 +762,7 @@ def test_get_voyages_complete_execution_path():
             }
         else:
             mock_resp.json.return_value = {"payload": []}
+
         return mock_resp
 
     # Mock secondary call handlers internal to get_voyages loop execution path
@@ -846,7 +843,6 @@ def test_get_orders_complete_execution_path():
 # =====================================================================
 # ITEM 5 TESTS: Client/Server Target Price Comparison Key Alignment
 # =====================================================================
-
 def test_parse_dining_includes_table_size(mock_booking_with_dining_and_checkin):
     """
     Verify that the dining log output zero-pads and includes the table size
@@ -874,20 +870,24 @@ def test_parse_dining_includes_table_size(mock_booking_with_dining_and_checkin):
         }
     }
     mock_promo_response = {"payload": []}
-    mock_order_response = {"payload": []}  # Safe fallback for get_orders execution path
+    mock_order_response = {"payload": []}
 
-    # Dynamic network router instead of a strict sequence
+    # Dynamic network router returning response objects with complete status attributes
     def api_router(*args, **kwargs):
-        # Inspect URL string passed into positional arguments
         url_called = args[2] if len(args) > 2 else kwargs.get("url", "")
 
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = '{"rooms": []}'
+
         if "promotions/list" in url_called:
-            return MagicMock(json=lambda: mock_promo_response)
+            mock_resp.json.return_value = mock_promo_response
         elif "orderHistory" in url_called:
-            return MagicMock(json=lambda: mock_order_response)
+            mock_resp.json.return_value = mock_order_response
         else:
-            # Default to the primary booking payload profile
-            return MagicMock(json=lambda: mock_bookings_response)
+            mock_resp.json.return_value = mock_bookings_response
+
+        return mock_resp
 
     mock_metrics = {"passenger_names": "Matt Smith", "checkin_string": "Boarding Time 12:00"}
 
@@ -904,7 +904,9 @@ def test_parse_dining_includes_table_size(mock_booking_with_dining_and_checkin):
         "prices": [{"priceTypeCode": "GROSS_TOTALS", "amount": 2662.96}]
     }
 
+    # Added patch for get_cruise_price to isolate dining verification from pricing cascades
     with patch('CheckRoyalCaribbeanPrice._execute_api_request', side_effect=api_router), \
+         patch('CheckRoyalCaribbeanPrice.get_cruise_price'), \
          patch('CheckRoyalCaribbeanPrice._calculate_passenger_metrics', return_value=mock_metrics), \
          patch('CheckRoyalCaribbeanPrice.get_dining_and_prices', return_value=mock_dining_and_prices), \
          patch('CheckRoyalCaribbeanPrice.get_checkin_info'), \
@@ -987,28 +989,79 @@ def test_parse_granular_checkin_per_passenger(mock_booking_with_dining_and_check
 # =====================================================================
 # ITEM 6 FOUNDATIONAL TESTS: Low-level Network & Helper Verification
 # =====================================================================
-
-def test_execute_api_request_handles_uninitialized_access_context():
+def test_parse_granular_checkin_per_passenger(mock_booking_with_dining_and_checkin):
     """
-    Ensure the network engine falls back cleanly to the standard requests
-    module if account_info is passed but access configurations are missing.
+    Verify that individual passenger check-in statuses and boarding constraints
+    are clearly enumerated inside the log stream.
     """
-    # Create an AccountInfo model wrapper where access profile is explicit None
-    account_info = AccountInfo(username="tester", password="password", cruise_line="royal")
-    account_info.access = None
+    account_info = AccountInfo(username="test_user", password="password", cruise_line="royal")
+    account_info.access = MagicMock()
 
-    mock_response = MagicMock()
-    mock_response.raise_for_status.return_value = None
+    discounts = CruiseURLParams(loyalty_number="390323599", state="FL", dp340=False)
+    ship_registry = ShipRegistry()
 
-    with patch('CheckRoyalCaribbeanPrice.requests.Session.request', return_value=mock_response) as mock_req:
-        resp = _execute_api_request(
-            account_info=account_info,
-            method="GET",
-            url="https://aws-prd.api.rccl.com/test-endpoint",
-            on_failure="retry"
-        )
-        assert resp is not None
-        mock_req.assert_called_once()
+    mock_bookings_response = {
+        "payload": {
+            "profileBookings": [{
+                "bookingId": "9999999",
+                "passengerId": "33333333",
+                "sailDate": "20270510",
+                "numberOfNights": 7,
+                "shipCode": "WN",
+                "stateroomNumber": "6574",
+                "stateroomType": "B",
+                "passengersInStateroom": [{"firstName": "Matt", "lastName": "Smith", "bookingId": "9999999"}]
+            }]
+        }
+    }
+    mock_promo_response = {"payload": []}
+    mock_order_response = {"payload": []}
+
+    def api_router(*args, **kwargs):
+        url_called = args[2] if len(args) > 2 else kwargs.get("url", "")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = '{"rooms": []}'
+
+        if "promotions/list" in url_called:
+            mock_resp.json.return_value = mock_promo_response
+        elif "orderHistory" in url_called:
+            mock_resp.json.return_value = mock_order_response
+        else:
+            mock_resp.json.return_value = mock_bookings_response
+
+        return mock_resp
+
+    checkin_logs = []
+    for guest in mock_booking_with_dining_and_checkin["guests"]:
+        name = guest["firstName"]
+        status = guest["checkInStatus"]
+        b_time = guest["boardingTime"].replace(" PM", "").strip()
+        checkin_logs.append(f"{name} Check in {status}, Boarding Time {b_time}")
+
+    mock_metrics = {
+        "passenger_names": "Bob, Matt",
+        "checkin_string": ", ".join(checkin_logs)
+    }
+
+    mock_dining_and_prices = {
+        "dining_selection": [{"sittingType": "TRADITIONAL", "sittingTime": "05:00 PM", "tableSize": "04"}],
+        "prices": [{"priceTypeCode": "GROSS_TOTALS", "amount": 2662.96}]
+    }
+
+    with patch('CheckRoyalCaribbeanPrice._execute_api_request', side_effect=api_router), \
+         patch('CheckRoyalCaribbeanPrice.get_cruise_price'), \
+         patch('CheckRoyalCaribbeanPrice._calculate_passenger_metrics', return_value=mock_metrics), \
+         patch('CheckRoyalCaribbeanPrice.get_dining_and_prices', return_value=mock_dining_and_prices), \
+         patch('CheckRoyalCaribbeanPrice.get_checkin_info'), \
+         patch('CheckRoyalCaribbeanPrice.log') as mock_log:
+
+        get_voyages(account_info, discounts, ship_registry)
+
+        log_outputs = [call[0][0] for call in mock_log.call_args_list]
+        assert any("Bob Check in Partially Complete, Boarding Time 12:00" in s for s in log_outputs), \
+            "Granular passenger check-in layout contract was missed!"
 
 
 @patch("time.sleep", return_value=None)  # Fast execution warp drive
@@ -1214,7 +1267,6 @@ def test_get_ship_dictionary_web_exception_handling_triggers_exit():
 # =====================================================================
 # ITEM 8 EXTRA PARSER & SESSION TESTS: Edge-Case Handling & Robust Fallbacks
 # =====================================================================
-
 def test_parse_provided_url_handles_empty_or_missing_list_parameters():
     """
     Ensure the URL engine safely extracts values without throwing an IndexError
@@ -1454,10 +1506,9 @@ def test_get_cruise_price_resolves_boolean_discount_labels_accurately():
         # This test documents that the script updates should check `is True` or truthiness.
         assert "Loyalty" in logged_messages or "Residency" in logged_messages
 
-#======================================================================
+# ======================================================================
 # ITEM 11 EXTRA LIVE API TESTS: Schema Alignment & Request Resilience
 # =====================================================================
-
 def test_get_room_price_via_api_suite_schema_realignment():
     """
     Ensure the checkout payload correctly remaps suite category codes to 'SUITE'
@@ -1514,7 +1565,6 @@ def test_check_if_room_is_available_network_exception_tolerance():
 # =====================================================================
 # ITEM 12 EXTRA ADD-ON ENGINE TESTS: Cost Metrics & Promotion Boundaries
 # =====================================================================
-
 def test_get_orders_per_day_price_calculation_safety():
     """
     Ensure get_orders divides the package subtotal accurately without
@@ -1737,7 +1787,6 @@ def test_calculate_passenger_metrics_brittle_timestamp_fallback():
 # =====================================================================
 # ITEM 14 ORCHESTRATION & RUN CONTROL TESTS: Configuration Lifecycle
 # =====================================================================
-
 def test_load_config_objects_handles_none_values_safely(tmp_path):
     """
     Ensure load_config_objects safely parses a YAML configuration even when
@@ -2129,7 +2178,7 @@ def test_exact_price_match_includes_obc(monkeypatch):
 
 
 # =====================================================================
-# ITEM 18: "NOT FOR SALE" AVAILABILITY GATE - MATCH ON SUBTYPE CODE ALONE
+# ITEM 17: "NOT FOR SALE" AVAILABILITY GATE - MATCH ON SUBTYPE CODE ALONE
 # =====================================================================
 def _room_selection_rsc(code="D", category_code="4D"):
     """Minimal room-selection RSC payload exposing one stateroom subtype."""
@@ -2163,31 +2212,37 @@ def _availability_params(subtype, category_code):
 
 
 def test_availability_matches_on_subtype_code_even_when_category_differs():
-    """The 'Not For Sale' fix: gate on subtype code alone. The endpoint returns code 'D' with
-    its lead-in category '4D'; a booking in category '2D' must still be found AVAILABLE. A
-    regression to a two-field code+categoryCode match would fail this (2D != 4D)."""
-    params = _availability_params(subtype="D", category_code="2D")  # booked above the lead-in
+    params = _availability_params(subtype="D", category_code="2D")
+
     mock_resp = MagicMock()
+    mock_resp.status_code = 200
     mock_resp.text = _room_selection_rsc(code="D", category_code="4D")
-    with patch('CheckRoyalCaribbeanPrice.requests.get', return_value=mock_resp):
+
+    with patch('CheckRoyalCaribbeanPrice._execute_api_request', return_value=mock_resp):
         available, alternates = check_if_room_is_available(params)
+
     assert available is True
     assert alternates == []
 
 
 def test_availability_false_when_subtype_code_absent():
-    """A subtype not present in the response is unavailable, and its alternatives are returned."""
     params = _availability_params(subtype="Z", category_code="9Z")
+
     mock_resp = MagicMock()
+    mock_resp.status_code = 200
     mock_resp.text = _room_selection_rsc(code="D", category_code="4D")
-    with patch('CheckRoyalCaribbeanPrice.requests.get', return_value=mock_resp):
+
+    with patch('CheckRoyalCaribbeanPrice._execute_api_request', return_value=mock_resp):
         available, alternates = check_if_room_is_available(params)
+
     assert available is False
     assert len(alternates) == 1
     assert alternates[0]["name"].startswith("Ocean View Balcony")
 
 
-# ITEM 17: END-OF-RUN CHECK-IN & FINAL-PAYMENT SUMMARY TABLE
+# =====================================================================
+# ITEM 18: END-OF-RUN CHECK-IN & FINAL-PAYMENT SUMMARY TABLE
+# =====================================================================
 def test_checkin_payment_summary_table_renders_and_flags():
     """print_checkin_payment_table sorts by sail date and colour-codes paid vs balance-due."""
     import CheckRoyalCaribbeanPrice as crccl
@@ -2294,7 +2349,6 @@ def test_summary_table_keeps_distinct_reservations():
 # A null/absent balanceDue must never render as "(paid)"; only an explicit
 # False may. Null with a positive balanceDueAmount is a balance due.
 # =====================================================================
-
 def _run_payment_table(monkeypatch, row_overrides):
     import CheckRoyalCaribbeanPrice as crccl
     from datetime import date as _date
@@ -2356,11 +2410,10 @@ def test_derive_balance_due_states():
 
 
 # =====================================================================
-# API TIMEOUT / RETRY CONSTANTS
+# ITEM 20: API TIMEOUT / RETRY CONSTANTS
 # Tunables live in the constants section rather than as scattered
 # magic numbers; pin their values so a change is a conscious decision.
 # =====================================================================
-
 def test_timeout_retry_constants():
     import CheckRoyalCaribbeanPrice as crccl
     assert crccl.REQUEST_TIMEOUT == 30


### PR DESCRIPTION
I made some architectural changes to the fix for https://github.com/jdeath/CheckRoyalCaribbeanPrice/issues/88 to take advantage of the enhancements in _execute_api_request (such as retries and different failure paths).  It also keeps all API calls in one place (in the function) and follows DRY (Don't Repeat Yourself) by removing the last remaining server call that didn't use that function.   Also updated _execute_api_requiest in BrowseRoyalCaribbeanPrice so it is exactly the same as the one in CheckRoyalCaribbeanPrice (they are purposely kept separated so any updates must be done in tandem)

1. Augmented _execute_api_request to be able to turn on/off impersonation per call
2. Replaced 'request_normal' call wtih augmented _execute_api_request in get_room_price_via_API
3. Updated BrowseRoyalCaribbeanPrice::_execute_api_request to match CheckRoyalCaribbeanPrice::_execute_api_request
4. Updated unit test code to accommodate these changes