### PR TITLE
Fix TA bookings: omit None params from checkout URL (countryCode='None' -> HTTP 400)

### DIFF
--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -2686,6 +2686,15 @@ def _build_checkout_url(
     else:
         base_url = f"https://www.{account_info.url_brand}.com/room-selection/room-location"
 
+    # Drop parameters with no value: urlencode() would otherwise stringify
+    # None into the literal string "None" (e.g. travel-agent bookings that
+    # carry no bookingOfficeCountryCode). Downstream URL parsing would then
+    # forward countryCode="None" to the checkout API, which rejects it with
+    # HTTP 400 BAD_INPUT ("must match pattern ^[A-Z]{3}$") and the cabin
+    # reports "Room Price Not Found". Omitting the key lets
+    # parse_provided_URL() fall back to its defaults (country -> "USA").
+    params = {key: value for key, value in params.items() if value is not None}
+
     # Seamlessly combine the base URL and the safely encoded string
     return f"{base_url}?{urlencode(params)}"
 

--- a/test_price_checker.py
+++ b/test_price_checker.py
@@ -2525,3 +2525,44 @@ def test_derive_balance_due_ta_agency_flagged_unknown():
     # Test bookingType: "G" match (from reservation 3523878)
     booking3 = {"balanceDue": None, "paidInFull": False, "bookingType": "G"}
     assert derive_balance_due(booking3, []) == "TA_UNKNOWN"
+
+
+# ITEM 22 TESTS: TA BOOKINGS WITHOUT bookingOfficeCountryCode (checkout URL None params)
+
+def test_build_checkout_url_omits_none_params_for_ta_bookings():
+    """A travel-agent booking that carries no bookingOfficeCountryCode must not
+    leak the literal string 'None' into the checkout URL. urlencode() would
+    stringify the None, parse_provided_URL() would read it back verbatim, and
+    the checkout API would reject countryCode='None' with HTTP 400 BAD_INPUT
+    ('must match pattern ^[A-Z]{3}$') -- reporting 'Room Price Not Found' for
+    a cabin that is actually on sale. Omitting the key lets the parser fall
+    back to its default (country -> 'USA')."""
+    from CheckRoyalCaribbeanPrice import parse_provided_URL
+
+    account_info = AccountInfo(username="test_user", password="password", cruise_line="royal")
+    discounts = DiscountProfile(
+        loyalty_number=None, state=None, senior=False,
+        military=False, fire=False, police=False, dp340=False
+    )
+    metrics = {
+        'num_adults': 2, 'num_children': 0, 'sub_type': 'I1',
+        'category_code': 'I1', 'have_a_senior': False
+    }
+    booking = {
+        'packageCode': 'ST07E490',
+        'sailDate': '20270124',
+        'bookingCurrency': 'USD',
+        'shipCode': 'ST',
+        'stateroomNumber': '11588',
+        'stateroomType': 'B',
+        # NOTE: intentionally no 'bookingOfficeCountryCode' key (TA booking)
+    }
+
+    url = _build_checkout_url(booking, metrics, account_info, discounts)
+
+    assert "country=None" not in url
+    assert "None" not in url  # no parameter may stringify a Python None
+
+    parsed = parse_provided_URL(url)
+    assert parsed.booking_office_country_code == "USA"
+    assert parsed.sail_date == "2027-01-24"  # checkout API requires the dashed form


### PR DESCRIPTION
Fixes #107.

### What happens

Travel-agent bookings can come back from the bookings API without a `bookingOfficeCountryCode` key. `_build_checkout_url()` puts the resulting Python `None` into its params dict, `urlencode()` stringifies it to the literal text `country=None`, `parse_provided_URL()` reads the string `"None"` back verbatim (its `"USA"` default only fires when the key is *absent*), and the `/checkout/api/v1/rooms/checkout` POST sends `countryCode: "None"` — which the API rejects with HTTP 400 BAD_INPUT (`must match pattern "^[A-Z]{3}$"`). The availability GET tolerates the bad value, so the cabin passes availability and then logs "Room Price Not Found" / shows Not For Sale despite being buyable. Full live-API evidence matrix in #107.

### The fix

Filter `None` values from the params dict before `urlencode()`, so the parser's existing defaults apply (`country` → `"USA"`, currency → `"USD"`):

```python
params = {key: value for key, value in params.items() if value is not None}
```

This also stops **any** other absent field from leaking as the literal `"None"` — including a GTY booking that reaches the builder with an unresolved category/subtype (`r0e`/`r0f` = `None`), which is why this may well be a cousin of the failures #105 addresses, per your comment. The two changes compose cleanly — we're running both together on our fork.

### Testing

- New regression test (ITEM 22): builds a booking without `bookingOfficeCountryCode`, asserts the generated URL contains no `"None"`, and round-trips `parse_provided_URL` to `country == "USA"` with the dashed sail date. Fails before the fix, passes after.
- Full suite passes on this branch (172 passed).
- Live-verified against the checkout API: `"USA"` → 200 with priced rooms; `"None"`/`null`/absent → 400. A previously "Not For Sale" TA-booked, assigned (non-GTY) cabin prices correctly with this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
