### PR TITLE
login(): surface the OAuth error body so a 400 is diagnosable

### DIFF
--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -1030,7 +1030,20 @@ def login(account_info: AccountInfo) -> APIAccess:
         sys.exit(1)
 
     if response.status_code != 200:
-        log(f"Login attempt got return code {response.status_code}")
+        log(f"Login attempt got return code {response.status_code} for user {account_info.username}")
+
+        # The status code alone cannot distinguish a rejected password
+        # ("invalid_grant") from a malformed request ("invalid_request") or an
+        # edge/WAF block that returns HTML - which makes a login failure very
+        # hard to diagnose. Surface the server's own error text; the OAuth
+        # error body carries no credentials, and the password is scrubbed
+        # defensively in case an echo is ever added.
+        detail = (response.text or "").strip()
+        if password and password in detail:
+            detail = detail.replace(password, "***")
+        if detail:
+            log(f"	Server said: {detail[:300]}")
+
         log(f"{account_info.cruise_line} website might be down, username/password incorrect, or have unsupported symbol in password. Quitting.")
         sys.exit(1)
 

--- a/test_price_checker.py
+++ b/test_price_checker.py
@@ -2566,3 +2566,59 @@ def test_build_checkout_url_omits_none_params_for_ta_bookings():
     parsed = parse_provided_URL(url)
     assert parsed.booking_office_country_code == "USA"
     assert parsed.sail_date == "2027-01-24"  # checkout API requires the dashed form
+
+
+# ITEM 23 TESTS: LOGIN FAILURE DIAGNOSTICS (OAuth error body surfaced)
+
+def test_login_failure_logs_server_error_body_and_scrubs_password():
+    """A bare status code cannot tell a rejected password ('invalid_grant')
+    from a malformed request ('invalid_request') or an edge/WAF block, which
+    makes login failures undiagnosable from a run log. login() must surface
+    the server's own error text -- with the password scrubbed if it ever
+    appears in the response."""
+    import CheckRoyalCaribbeanPrice as C
+
+    account_info = AccountInfo(username="someone@example.com", password="pa55!word", cruise_line="royal")
+
+    bad_response = MagicMock()
+    bad_response.status_code = 400
+    bad_response.text = '{"error_description":"Login failure","error":"invalid_grant"}'
+
+    mock_session = MagicMock()
+    mock_session.post.return_value = bad_response
+
+    logged: list[str] = []
+    with patch.object(C, "new_api_session", return_value=mock_session), \
+         patch.object(C, "log", side_effect=lambda msg="", *a, **k: logged.append(str(msg))):
+        with pytest.raises(SystemExit):
+            C.login(account_info)
+
+    joined = "\n".join(logged)
+    assert "invalid_grant" in joined, "the server's OAuth error must reach the run log"
+    assert "someone@example.com" in joined, "the failing account should be identifiable"
+    assert "pa55!word" not in joined, "the password must never be logged"
+
+
+def test_login_failure_scrubs_password_echoed_in_body():
+    """Defensive: if the endpoint ever echoes the submitted password back in
+    an error body, it must not land in the log."""
+    import CheckRoyalCaribbeanPrice as C
+
+    account_info = AccountInfo(username="someone@example.com", password="pa55!word", cruise_line="royal")
+
+    bad_response = MagicMock()
+    bad_response.status_code = 400
+    bad_response.text = '{"error":"invalid_request","detail":"password pa55!word rejected"}'
+
+    mock_session = MagicMock()
+    mock_session.post.return_value = bad_response
+
+    logged: list[str] = []
+    with patch.object(C, "new_api_session", return_value=mock_session), \
+         patch.object(C, "log", side_effect=lambda msg="", *a, **k: logged.append(str(msg))):
+        with pytest.raises(SystemExit):
+            C.login(account_info)
+
+    joined = "\n".join(logged)
+    assert "pa55!word" not in joined
+    assert "***" in joined


### PR DESCRIPTION
### The problem

When a login fails, the run prints only the status code:

```
Login attempt got return code 400
royalcaribbean website might be down, username/password incorrect, or have unsupported symbol in password. Quitting.
```

That one line has to cover three completely different failures, and it can't distinguish them:

- `invalid_grant` — the password really is wrong
- `invalid_request` — the request shape is off (a client/API change)
- an edge/WAF block returning HTML — nothing to do with the credentials at all

A real case from this week: a two-account config started failing at login. The account's credentials turned out to be fine on one path and stale on another, and with only "return code 400" there was no way to tell which account was even at fault, or whether Royal had changed something. Adding one line of output turned an open-ended investigation into a one-run answer:

```
Login attempt got return code 400 for user someone@example.com
	Server said: {"error_description":"6","error":"invalid_grant"}
```

### The change

Log the server's own error text (capped at 300 chars) and the failing username alongside the status code. The OAuth error body carries no credentials; the password is additionally scrubbed defensively in case an echo is ever introduced.

### Testing

Two tests added (ITEM 23): the server's error reaches the log and the account is identifiable, and the password never appears in the output even if the response body echoes it. Full suite green on this branch (174 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
