### PR TITLE
History layer follow-ups: consistent sail_date/nights across rows, plus bookings/promos snapshot tables

### DIFF
--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -481,6 +481,12 @@ class AccountInfo:
     access: Optional[APIAccess] = None
     found_items: Set[str] = field(default_factory=set)
 
+    # Populated in main() right after get_profile(); history-layer snapshot
+    # fields only (C&A/Captain's Club tier label + individual points) - not
+    # used anywhere in alert/discount logic.
+    loyalty_tier: Optional[str] = None
+    loyalty_points: Optional[int] = None
+
     # Live Runtime Object (excluded from the YAML mapping, like config.apobj).
     # Per-account Apprise object; falls back to the global config.apobj via
     # notifier_for() when this account has no apprise: list of its own.
@@ -650,6 +656,47 @@ CREATE INDEX IF NOT EXISTS idx_price_points_history
 
 CREATE INDEX IF NOT EXISTS idx_price_points_run
     ON price_points (run_id);
+
+CREATE TABLE IF NOT EXISTS bookings (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id           INTEGER NOT NULL REFERENCES runs(run_id),
+    observed_at      TEXT NOT NULL,
+    account_label    TEXT,                 -- account_info.username
+    reservation_id   TEXT NOT NULL,
+    ship_code        TEXT,
+    ship_name        TEXT,                 -- from the ShipRegistry the run already built
+    sail_date        TEXT,                 -- YYYYMMDD
+    nights           INTEGER,
+    stateroom_type   TEXT,                 -- e.g. BALCONY / INTERIOR / GTY label as the script prints it
+    stateroom_number TEXT,                 -- may be NULL (GTY not yet assigned)
+    stateroom_category TEXT,               -- e.g. 4D
+    guest_count      INTEGER,
+    guests_json      TEXT,                 -- [{"name": "...", "id": "...", "age_bracket": "adult"}]
+    loyalty_tier     TEXT,                 -- from get_profile(): C&A tier label; NULL if unknown
+    loyalty_points   INTEGER,
+    checkin_label    TEXT,                 -- the string the summary table prints (e.g. "Opens Dec 10 8:00 AM")
+    final_payment_date TEXT,               -- YYYYMMDD, from get_final_payment_date
+    past_final_payment INTEGER,            -- 0/1
+    balance_due      INTEGER,              -- 1 / 0 / NULL (unknown, TA bookings)
+    booking_currency TEXT,
+    friendly_name    TEXT                  -- reservationFriendlyNames entry if configured
+);
+CREATE INDEX IF NOT EXISTS idx_bookings_latest ON bookings (reservation_id, observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS promos (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id           INTEGER NOT NULL REFERENCES runs(run_id),
+    observed_at      TEXT NOT NULL,
+    account_label    TEXT,
+    ship_code        TEXT,
+    sail_date        TEXT,
+    promo_id         TEXT,
+    promo_title      TEXT,
+    promo_line       TEXT,                 -- the human-readable line the script logs
+    promo_start      TEXT,
+    promo_end        TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_promos_run ON promos (run_id);
 """
 
 
@@ -707,18 +754,6 @@ class PriceHistory:
         conn.execute("PRAGMA journal_mode=WAL")
         return conn
 
-    def _insert(self, **fields: Any) -> None:
-        fields.setdefault("observed_at", datetime.now(timezone.utc).isoformat())
-        fields["run_id"] = self._current_run_id
-        cols = ", ".join(fields)
-        placeholders = ", ".join("?" for _ in fields)
-        try:
-            with closing(self._connect()) as conn:
-                conn.execute(f"INSERT INTO price_points ({cols}) VALUES ({placeholders})", tuple(fields.values()))
-                conn.commit()
-        except (sqlite3.Error, OSError) as e:
-            self._disable(e)
-
     def start_run(self) -> Optional[int]:
         """Opens a new `runs` row and remembers it as the active run."""
         if not self.enabled:
@@ -754,13 +789,37 @@ class PriceHistory:
         """Appends one `price_points` row for a cabin-fare observation."""
         if not self.enabled or self._current_run_id is None:
             return
-        self._insert(item_kind="cabin_fare", **fields)
+        self._insert("price_points", item_kind="cabin_fare", **fields)
 
     def record_addon(self, **fields: Any) -> None:
         """Appends one `price_points` row for an addon/watchlist observation."""
         if not self.enabled or self._current_run_id is None:
             return
-        self._insert(**fields)
+        self._insert("price_points", **fields)
+
+    def record_booking(self, **fields: Any) -> None:
+        """Appends one `bookings` row: a full snapshot of one reservation this run."""
+        if not self.enabled or self._current_run_id is None:
+            return
+        self._insert("bookings", **fields)
+
+    def record_promo(self, **fields: Any) -> None:
+        """Appends one `promos` row for one active sitewide promotion this run."""
+        if not self.enabled or self._current_run_id is None:
+            return
+        self._insert("promos", **fields)
+
+    def _insert(self, table: str, **fields: Any) -> None:
+        fields.setdefault("observed_at", datetime.now(timezone.utc).isoformat())
+        fields["run_id"] = self._current_run_id
+        cols = ", ".join(fields)
+        placeholders = ", ".join("?" for _ in fields)
+        try:
+            with closing(self._connect()) as conn:
+                conn.execute(f"INSERT INTO {table} ({cols}) VALUES ({placeholders})", tuple(fields.values()))
+                conn.commit()
+        except (sqlite3.Error, OSError) as e:
+            self._disable(e)
 
 
 class CheckinPaymentTracker:
@@ -1435,7 +1494,10 @@ def get_profile(account_info: AccountInfo) -> Tuple[Optional[str], Optional[str]
 
     Inspects user contact records to locate primary residency states and tracks concurrent
     loyalty modules (Crown & Anchor, Club Royale, Captain's Club, and Blue Chip). Returns
-    the active brand tracking index to route downstream web requests correctly.
+    the active brand tracking index to route downstream web requests correctly. Also stashes
+    the active-brand loyalty tier label and individual points directly onto account_info
+    (history-layer snapshot fields only - never read by any discount/alert logic) since
+    account_info is already in hand here and get_voyages()'s signature must not change.
     """
     url = f"https://aws-prd.api.rccl.com/en/{account_info.api_brand}/web/v3/guestAccounts/{account_info.access.id}"
     response = _execute_api_request(account_info, "GET", url)
@@ -1479,6 +1541,8 @@ def get_profile(account_info: AccountInfo) -> Tuple[Optional[str], Optional[str]
             log(f"\tCasino Royale Tier: {club_royale_loyalty_tier} - {casino_points} Credits")
 
     # Get and display Celebrity (Captain's Club and Blue Chip) information
+    cc_level = None
+    cc_individual = 0
     if captains_club_ID:
         cc_level = loyalty.get("captainsClubLoyaltyTier")
         cc_individual = loyalty.get("captainsClubLoyaltyIndividualPoints", 0)
@@ -1496,6 +1560,12 @@ def get_profile(account_info: AccountInfo) -> Tuple[Optional[str], Optional[str]
 
     # Return the correct loyality number based on the account being used
     loyalty_number_to_use = captains_club_ID if account_info.is_celebrity else c_and_a_number
+
+    # History-layer snapshot only (bookings.loyalty_tier / loyalty_points) - stashed
+    # directly on account_info since it's already in hand; not used in any
+    # discount/alert calculation and not part of this function's return contract
+    account_info.loyalty_tier = cc_level if account_info.is_celebrity else c_and_a_level
+    account_info.loyalty_points = cc_individual if account_info.is_celebrity else c_and_a_points
 
     # Return Royal Crown and Anchor shared points to determine if eligible for dp340
     return state, loyalty_number_to_use, c_and_a_shared_points
@@ -1756,7 +1826,8 @@ def get_voyages(
 
         # Record this booking for the end-of-run check-in / final-payment summary table.
         # Include the room number so multiple cabins on the same sailing are distinct.
-        summary_name = ship_dictionary.get_ship(ship_code)
+        ship_name = ship_dictionary.get_ship(ship_code)
+        summary_name = ship_name
         if stateroom_number:
             summary_name += f" ({stateroom_number})"
         summary_reservation = str(reservation_ID)
@@ -1768,6 +1839,7 @@ def get_voyages(
         if str(reservation_ID) in config.paid_reservations:
             balance_due = False   # user vouches for it (reservationsPaidInFull)
 
+        past_final_payment = date.today() > final_payment_date
         if payment_tracker is not None:
             payment_tracker.record_row({
                     "name": summary_name,
@@ -1775,10 +1847,42 @@ def get_voyages(
                     "sail_date": sail_date,
                     "checkin_label": checkin_label or "TBD",
                     "final_payment": final_payment_date,
-                    "past_final_payment": date.today() > final_payment_date,
+                    "past_final_payment": past_final_payment,
                     "balance_due": balance_due,
                     "dedupe_key": f"{reservation_ID}|{sail_date}",
         })
+
+        # Snapshot this booking for the history layer (opt-in, no-op when disabled).
+        # 1/0/NULL tri-state matches the summary table's balance_due handling above.
+        guests_json = json.dumps([
+            {
+                "name": g.get("firstName", "").capitalize(),
+                "id": g.get("passengerId"),
+                "age_bracket": "adult" if above_age_on_sail_date(g.get("birthdate"), sail_date, 12) else "child",
+            }
+            for g in guests
+        ])
+        config.history.record_booking(
+            reservation_id=str(reservation_ID),
+            ship_code=ship_code,
+            ship_name=ship_name,
+            sail_date=sail_date,
+            nights=number_of_nights,
+            stateroom_type=stateroom_type_name,
+            stateroom_number=stateroom_number if stateroom_number and stateroom_number != "GTY" else None,
+            stateroom_category=metrics.get('category_code'),
+            guest_count=len(guests),
+            guests_json=guests_json,
+            loyalty_tier=account_info.loyalty_tier,
+            loyalty_points=account_info.loyalty_points,
+            checkin_label=checkin_label or "TBD",
+            final_payment_date=final_payment_date.strftime("%Y%m%d"),
+            past_final_payment=int(past_final_payment),
+            balance_due={True: 1, False: 0}.get(balance_due),
+            booking_currency=booking_currency,
+            friendly_name=reservation_friendly_names.get(str(reservation_ID)),
+            account_label=account_info.username,
+        )
 
         if balance_due is True:
             owed = (f"{balance_due_amount:.2f}" if isinstance(balance_due_amount, (int, float))
@@ -3123,7 +3227,8 @@ def get_all_promotions(account_info: AccountInfo, booking: Dict[str, Any]) -> No
 
         banner = banner_by_id.get(promo_ID)
         if banner:
-            promo_line = f"[PROMO] {banner.get('heading3', '')} {banner.get('heading4', '')} - {banner.get('heading1', '')} {date_range}"
+            promo_title = f"{banner.get('heading3', '')} {banner.get('heading4', '')} - {banner.get('heading1', '')}"
+            promo_line = f"[PROMO] {promo_title} {date_range}"
         else:
             template = next((t for t in promo.get("templates", []) if isinstance(t, dict) and t.get("type") == "HOME_HERO_LOCKUP"), None)
             if not template:
@@ -3149,11 +3254,17 @@ def get_all_promotions(account_info: AccountInfo, booking: Dict[str, Any]) -> No
                     description = " ".join(words).upper()
 
             category_code = template.get("categoryCode", "")
-            promo_line = f"[PROMO] {description or promo_ID}"
+            promo_title = description or promo_ID
+            promo_line = f"[PROMO] {promo_title}"
             if category_code:
                 promo_line += f" ({category_code})"
             promo_line += f" {date_range}"
 
+        config.history.record_promo(
+            account_label=account_info.username, ship_code=ship, sail_date=start_date,
+            promo_id=promo_ID, promo_title=promo_title, promo_line=promo_line,
+            promo_start=promo_start, promo_end=promo_end,
+        )
         log(YELLOW + promo_line + RESET)
 
 

--- a/CheckRoyalCaribbeanPrice.py
+++ b/CheckRoyalCaribbeanPrice.py
@@ -2086,13 +2086,32 @@ def get_cruise_price(account_info: AccountInfo,
     if used_discounts != "":
         pre_string = f"{pre_string} ({used_discounts[:-2]} Discount)"
 
+    # History must record sail_date/nights in the SAME form the addon/promo/
+    # booking-snapshot paths already use (the booking's raw YYYYMMDD sailDate
+    # and bare numberOfNights), not url_params.sail_date - that's the dashed
+    # date parsed back out of the checkout URL. Recording the dashed form
+    # here made a reservation with an add-on purchase produce two history
+    # rows that disagree on sail_date/nights for the same sailing, so a
+    # downstream viewer grouping on (reservation_id, ship_code, sail_date,
+    # nights) showed it as two separate cards. url_params.sail_date/
+    # resolved_nights stay exactly as-is for the final-payment computation
+    # above and everything else in this function; only what gets written to
+    # history changes. The synthetic prospective/watchlist booking (see the
+    # `prospective_booking` dict built for config.prospective_cruises) has no
+    # sailDate/numberOfNights of its own, so fall back to those already-
+    # resolved URL/API-derived values for that case, same as before.
+    history_number_of_nights = int(booking.get("numberOfNights") or 0) or None
+    if not booking.get("sailDate"):
+        history_number_of_nights = resolved_nights
+    history_sail_date = booking.get("sailDate") or url_params.sail_date
+
     # Fields shared by every PriceHistory.record_cabin_fare() call below;
     # each call site only adds current_price/status/rebook_decision/notified
     history_common = {
         # str-coerced to match the addon rows, so the two kinds join cleanly
         "reservation_id": str(reservation_id) if reservation_id is not None else None,
         "account_label": account_info.username,
-        "ship_code": url_params.ship_code, "sail_date": url_params.sail_date, "nights": resolved_nights,
+        "ship_code": url_params.ship_code, "sail_date": history_sail_date, "nights": history_number_of_nights,
         "item_code": f"{url_params.package_code}/{url_params.stateroom_category_code}",
         "paid_price": paid_price, "currency": url_params.currency_code,
         "discount_applied": used_discounts[:-2] if used_discounts else None,

--- a/docs/config.md
+++ b/docs/config.md
@@ -115,7 +115,7 @@ reservationsPaidInFull:
   - '8912345'
 ```
 
-To keep a local history of every price check (for tracking trends over time), set historyDb to a file path. It is optional and off by default - with it unset, nothing changes and no file is created. When set, every cabin fare and add-on/watchlist price check made during a run is appended as one row to a local SQLite file (a `runs` table per script run, plus a `price_points` table with the paid price, current price, and decision for each item checked).
+To keep a local history of every price check (for tracking trends over time), set historyDb to a file path. It is optional and off by default - with it unset, nothing changes and no file is created. When set, every cabin fare and add-on/watchlist price check made during a run is appended as one row to a local SQLite file (a `runs` table per script run, plus a `price_points` table with the paid price, current price, and decision for each item checked). Each run also appends one `bookings` row per reservation (ship, stateroom, guests, loyalty tier, check-in and final-payment status) and one `promos` row per active sitewide promotion found. The database file contains your login emails and reservation IDs in plain text - never share or commit it.
 ```yaml
 historyDb: "price_history.db"
 ```

--- a/unittests/test_alert_matrix.py
+++ b/unittests/test_alert_matrix.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, patch
 from CheckRoyalCaribbeanPrice import (
 # ITEM 1 TESTS: CRUISE FARE MATRIX: get_cruise_price
 # ITEM 2 TESTS ADD-ON MATRIX: get_new_order_price
+# ITEM 3 TESTS: HISTORY SAIL_DATE/NIGHTS CROSS-PATH CONSISTENCY (GTY-105)
     AccountInfo,
     WatchItemContext,
     get_cruise_price,
@@ -456,3 +457,96 @@ class TestAddonWatchlistAlerts:
         )
         apobj.notify.assert_not_called()
         mock_net.assert_not_called()
+
+
+# ==================================================
+# ITEM 3 TESTS: HISTORY SAIL_DATE/NIGHTS CROSS-PATH CONSISTENCY (GTY-105)
+# ==================================================
+class TestHistorySailDateNightsConsistency:
+    """
+    A reservation with an add-on purchase used to write two disagreeing
+    price_points rows for the same sailing: get_cruise_price() recorded
+    url_params.sail_date (the dashed "2026-09-13" the checkout URL is built
+    with) while get_new_order_price() recorded the booking's raw "20260913"
+    sailDate straight off the API. A downstream viewer grouping on
+    (reservation_id, ship_code, sail_date, nights) then showed the one
+    reservation as two identical cards. Both paths must now record the same
+    raw booking sailDate/numberOfNights, even though the checkout URL still
+    carries the dashed form (the API needs that form; only what gets
+    written to history changed).
+    """
+
+    def test_cabin_fare_history_uses_raw_booking_sail_date_and_nights(self):
+        """
+        The booking behind this price check sails 2026-09-13 / 7 nights, but
+        the checkout URL get_cruise_price() builds carries the dashed form
+        for the API request. record_cabin_fare() must still get the raw
+        booking values, not the dashed URL value.
+        """
+        booking = {
+            # make_checkout_url() embeds a dashed sailDate for a sailing ~400
+            # days out - deliberately NOT "20260913", so url_params.sail_date
+            # (parsed straight back out of this URL) can never accidentally
+            # match the raw booking sailDate below and mask a regression.
+            "url": make_checkout_url(400),
+            "bookingId": "1234567",
+            "sailDate": "20260913",
+            "numberOfNights": 7,
+        }
+        account = make_account()
+
+        mock_cfg = MagicMock()
+        mock_cfg.minimum_saving_alert = None
+        mock_cfg.currency_override = None
+        mock_cfg.date_display_format = "%m/%d/%Y"
+        mock_cfg.format_date = lambda d: str(d)
+
+        ship_dictionary = MagicMock()
+        ship_dictionary.get_ship.return_value = "Wonder of the Seas"
+
+        results = {**build_available_response(sailing_nights=7), "base_fare": build_fare(2500.0)}
+        with patch("CheckRoyalCaribbeanPrice.config", mock_cfg), \
+             patch("CheckRoyalCaribbeanPrice.log", MagicMock()), \
+             patch("CheckRoyalCaribbeanPrice.get_room_price_via_API", return_value=results):
+            get_cruise_price(
+                account, booking, ship_dictionary,
+                automatic_URL=True,
+                paid_price_struct={"paidPrice": 3000.0},
+            )
+
+        mock_cfg.history.record_cabin_fare.assert_called_once()
+        kwargs = mock_cfg.history.record_cabin_fare.call_args.kwargs
+        assert kwargs["sail_date"] == "20260913"
+        assert kwargs["nights"] == 7
+
+    def test_addon_history_records_same_sail_date_and_nights_as_cabin_fare(self):
+        """
+        The add-on path (get_new_order_price) has always written the raw
+        booking sailDate/numberOfNights - this pins that behavior down for
+        the exact same booking used above, so the two paths can't drift
+        apart again.
+        """
+        account = make_account()
+        booking = {"bookingId": "1234567", "shipCode": "WN", "sailDate": "20260913", "numberOfNights": 7}
+        ctx = WatchItemContext(
+            prefix="pt_beverage", product="3005", passenger_ID="PAX1", passenger_name="Jim",
+            room="6543", paid_price=50.0, guest_age_string="adult", sales_unit=None,
+            for_watch=False, owner=True, reservations=[],
+        )
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "payload": {"title": "Deluxe Beverage Package", "startingFromPrice": {"adultPromotionalPrice": 40.0}}
+        }
+        mock_cfg = MagicMock()
+        mock_cfg.minimum_saving_alert = None
+        mock_cfg.currency_override = None
+
+        with patch("CheckRoyalCaribbeanPrice.config", mock_cfg), \
+             patch("CheckRoyalCaribbeanPrice.log", MagicMock()), \
+             patch("CheckRoyalCaribbeanPrice._execute_api_request", return_value=mock_resp):
+            get_new_order_price(account, booking, MagicMock(), ctx)
+
+        mock_cfg.history.record_addon.assert_called_once()
+        kwargs = mock_cfg.history.record_addon.call_args.kwargs
+        assert kwargs["sail_date"] == "20260913"
+        assert kwargs["nights"] == 7

--- a/unittests/test_price_history.py
+++ b/unittests/test_price_history.py
@@ -12,6 +12,7 @@ test_alert_matrix.py):
     config.history.record_*.call_args.kwargs - the same "real object, mocked
     side effect" pattern already used for Apprise (A.5).
 """
+import json
 import os
 import pytest
 import sqlite3
@@ -24,8 +25,11 @@ from CheckRoyalCaribbeanPrice import (
     CruiseAppConfig,
     PriceHistory,
     WatchItemContext,
+    get_all_promotions,
     get_cruise_price,
+    get_final_payment_date,
     get_new_order_price,
+    get_voyages,
     load_config_objects,
     main,
 )
@@ -56,7 +60,8 @@ def test_price_history_is_noop_when_db_path_unset(tmp_path, monkeypatch):
 
 
 def test_price_history_creates_schema_on_first_use(tmp_path):
-    """Constructing against a real path creates the runs/price_points tables and all three indexes."""
+    """Constructing against a real path creates every table (price_points, bookings,
+    promos) and all of their indexes (PR 2 added bookings/promos to the #103 schema)."""
     db_path = tmp_path / "h.db"
     PriceHistory(str(db_path))
 
@@ -66,13 +71,15 @@ def test_price_history_creates_schema_on_first_use(tmp_path):
         tables = {r[0] for r in conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table'"
         ).fetchall()}
-        assert {"runs", "price_points"} <= tables
-        assert "promos" not in tables  # deferred to PR 2 (C.2 item 8)
+        assert {"runs", "price_points", "bookings", "promos"} <= tables
 
         indexes = {r[0] for r in conn.execute(
             "SELECT name FROM sqlite_master WHERE type='index'"
         ).fetchall()}
-        assert {"idx_price_points_latest", "idx_price_points_history", "idx_price_points_run"} <= indexes
+        assert {
+            "idx_price_points_latest", "idx_price_points_history", "idx_price_points_run",
+            "idx_bookings_latest", "idx_promos_run",
+        } <= indexes
     finally:
         conn.close()
 
@@ -528,3 +535,400 @@ def test_get_new_order_price_records_not_available_for_passenger():
     assert kwargs["item_kind"] == "watchlist"
     assert kwargs["item_code"] == "pt_beverage/3005"
     assert kwargs["current_price"] is None and kwargs["notified"] is False
+
+
+# =====================================================================
+# PART 3: PR 2 - `bookings` / `promos` snapshot tables
+# =====================================================================
+
+def test_price_history_upgrades_103_era_db_in_place(tmp_path):
+    """Opening a database created with ONLY the #103 schema (runs + price_points,
+    written here by hand) must add bookings/promos via CREATE TABLE IF NOT EXISTS
+    and leave pre-existing rows completely untouched."""
+    db_path = tmp_path / "h.db"
+    # The exact #103/#104-era schema (pre-PR2), verbatim minus "IF NOT EXISTS"
+    # so this represents a database that already exists on disk.
+    legacy_103_schema = """
+    CREATE TABLE runs (
+        run_id           INTEGER PRIMARY KEY AUTOINCREMENT,
+        started_at       TEXT NOT NULL,
+        finished_at      TEXT,
+        status           TEXT NOT NULL DEFAULT 'started',
+        error_summary    TEXT
+    );
+
+    CREATE TABLE price_points (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id           INTEGER NOT NULL REFERENCES runs(run_id),
+        observed_at      TEXT NOT NULL,
+        account_label    TEXT,
+        reservation_id   TEXT,
+        ship_code        TEXT,
+        sail_date        TEXT,
+        nights           INTEGER,
+        item_kind        TEXT NOT NULL,
+        item_code        TEXT,
+        item_name        TEXT,
+        guest_id         TEXT,
+        guest_name       TEXT,
+        paid_price       REAL,
+        current_price    REAL,
+        currency         TEXT,
+        per_night        INTEGER NOT NULL DEFAULT 0,
+        discount_applied TEXT,
+        status           TEXT NOT NULL,
+        rebook_decision  TEXT,
+        notified         INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE INDEX idx_price_points_latest
+        ON price_points (reservation_id, item_code, guest_id, observed_at DESC);
+
+    CREATE INDEX idx_price_points_history
+        ON price_points (item_code, sail_date, observed_at);
+
+    CREATE INDEX idx_price_points_run
+        ON price_points (run_id);
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(legacy_103_schema)
+        conn.execute(
+            "INSERT INTO runs (run_id, started_at, status) VALUES (1, '2026-01-01T00:00:00', 'ok')"
+        )
+        conn.execute(
+            "INSERT INTO price_points (run_id, observed_at, reservation_id, item_kind, status) "
+            "VALUES (1, '2026-01-01T00:00:00', '1234567', 'cabin_fare', 'priced')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Constructing PriceHistory against this #103-era file must upgrade it in place
+    history = PriceHistory(str(db_path))
+    assert history.enabled is True
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        tables = {r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()}
+        assert {"runs", "price_points", "bookings", "promos"} <= tables
+
+        indexes = {r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index'"
+        ).fetchall()}
+        assert {"idx_bookings_latest", "idx_promos_run"} <= indexes
+
+        # The old row must be untouched
+        old_row = conn.execute(
+            "SELECT run_id, reservation_id, item_kind, status FROM price_points"
+        ).fetchone()
+        assert old_row == (1, "1234567", "cabin_fare", "priced")
+    finally:
+        conn.close()
+
+
+def test_price_history_record_booking_round_trip(tmp_path):
+    """record_booking() writes a `bookings` row that reads back with every column intact."""
+    db_path = tmp_path / "h.db"
+    history = PriceHistory(str(db_path))
+    history.start_run()
+
+    guests_json = json.dumps([{"name": "Matt", "id": "33333333", "age_bracket": "adult"}])
+    history.record_booking(
+        account_label="user@example.com",
+        reservation_id="1234567",
+        ship_code="WN",
+        ship_name="Wonder of the Seas",
+        sail_date="20270601",
+        nights=7,
+        stateroom_type="BALCONY",
+        stateroom_number=None,
+        stateroom_category="4D",
+        guest_count=1,
+        guests_json=guests_json,
+        loyalty_tier="DIAMOND",
+        loyalty_points=4500,
+        checkin_label="Opens 12/10/2026 08:00 AM",
+        final_payment_date="20270303",
+        past_final_payment=0,
+        balance_due=1,
+        booking_currency="USD",
+        friendly_name="Anniversary Cruise",
+    )
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM bookings").fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row["account_label"] == "user@example.com"
+    assert row["reservation_id"] == "1234567"
+    assert row["ship_code"] == "WN"
+    assert row["ship_name"] == "Wonder of the Seas"
+    assert row["sail_date"] == "20270601"
+    assert row["nights"] == 7
+    assert row["stateroom_type"] == "BALCONY"
+    assert row["stateroom_number"] is None
+    assert row["stateroom_category"] == "4D"
+    assert row["guest_count"] == 1
+    assert json.loads(row["guests_json"]) == [{"name": "Matt", "id": "33333333", "age_bracket": "adult"}]
+    assert row["loyalty_tier"] == "DIAMOND"
+    assert row["loyalty_points"] == 4500
+    assert row["checkin_label"] == "Opens 12/10/2026 08:00 AM"
+    assert row["final_payment_date"] == "20270303"
+    assert row["past_final_payment"] == 0
+    assert row["balance_due"] == 1
+    assert row["booking_currency"] == "USD"
+    assert row["friendly_name"] == "Anniversary Cruise"
+
+
+def test_price_history_record_promo_round_trip(tmp_path):
+    """record_promo() writes a `promos` row that reads back with every column intact."""
+    db_path = tmp_path / "h.db"
+    history = PriceHistory(str(db_path))
+    history.start_run()
+
+    history.record_promo(
+        account_label="user@example.com",
+        ship_code="WN",
+        sail_date="20270601",
+        promo_id="P1",
+        promo_title="Early Booking Bonus",
+        promo_line="[PROMO] Early Booking Bonus (Valid 2027-01-01 to 2027-03-01)",
+        promo_start="2027-01-01",
+        promo_end="2027-03-01",
+    )
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM promos").fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row["promo_id"] == "P1"
+    assert row["promo_title"] == "Early Booking Bonus"
+    assert row["promo_line"] == "[PROMO] Early Booking Bonus (Valid 2027-01-01 to 2027-03-01)"
+    assert row["promo_start"] == "2027-01-01"
+    assert row["promo_end"] == "2027-03-01"
+    assert row["ship_code"] == "WN"
+    assert row["sail_date"] == "20270601"
+    assert row["account_label"] == "user@example.com"
+
+
+def test_price_history_record_booking_and_promo_noop_when_disabled(tmp_path, monkeypatch):
+    """With db_path unset, record_booking/record_promo must be silent no-ops that
+    never touch the filesystem, exactly like the #103 methods."""
+    monkeypatch.chdir(tmp_path)
+    before = set(os.listdir(tmp_path))
+
+    history = PriceHistory(None)
+    history.record_booking(reservation_id="1234567", ship_code="WN")
+    history.record_promo(promo_id="P1", ship_code="WN")
+
+    after = set(os.listdir(tmp_path))
+    assert after == before, f"record_booking/record_promo created filesystem entries: {after - before}"
+
+
+def test_price_history_record_booking_failure_isolation(tmp_path):
+    """A record_booking write error disables the sink (like the #103 methods) instead
+    of raising and taking down the run."""
+    db_path = tmp_path / "h.db"
+    history = PriceHistory(str(db_path))
+    history.start_run()
+
+    with patch.object(history, "_connect", side_effect=sqlite3.OperationalError("disk I/O error")):
+        history.record_booking(reservation_id="1234567", ship_code="WN")
+
+    assert history.enabled is False
+    history.record_booking(reservation_id="7654321")  # silent no-op now
+
+    conn = sqlite3.connect(db_path)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM bookings").fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 0  # the failed write never landed, and nothing crashed
+
+
+# ---------------------------------------------------------------------------
+# get_voyages() integration: one record_booking call per booking, per run
+# ---------------------------------------------------------------------------
+def make_voyages_account() -> AccountInfo:
+    account = AccountInfo(username="test_user", password="password", cruise_line="royal")
+    account.access = MagicMock()
+    account.access.token = "fake_token"
+    account.access.id = "fake_id"
+    account.loyalty_tier = "DIAMOND"
+    account.loyalty_points = 4500
+    return account
+
+
+def run_voyages_scenario(*, booking_extra=None):
+    """Drive the real get_voyages() against one mocked profileBookings response;
+    returns (mock_cfg, sail_date, booking) for assertions on record_booking."""
+    account = make_voyages_account()
+    sail_date = "20270601"
+    booking = {
+        "bookingId": "1234567",
+        "passengerId": "33333333",
+        "sailDate": sail_date,
+        "numberOfNights": 7,
+        "shipCode": "WN",
+        "stateroomNumber": "GTY",
+        "stateroomType": "B",
+        "bookingCurrency": "USD",
+        "passengersInStateroom": [
+            {"firstName": "matt", "passengerId": "33333333", "birthdate": "19800101", "stateroomCategoryCode": "4D"},
+            {"firstName": "jane", "passengerId": "44444444", "birthdate": "20200101", "stateroomCategoryCode": "4D"},
+        ],
+    }
+    if booking_extra:
+        booking.update(booking_extra)
+
+    def api_router(*args, **kwargs):
+        url = args[2] if len(args) > 2 else kwargs.get("url", "")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = "{}"
+        if "profileBookings" in url:
+            resp.json.return_value = {"payload": {"profileBookings": [booking]}}
+        else:
+            resp.json.return_value = {"payload": []}
+        return resp
+
+    mock_cfg = MagicMock()
+    mock_cfg.watch_list = []
+    mock_cfg.display_cruise_prices = False
+    mock_cfg.reservation_prices = {}
+    mock_cfg.reservation_names = {"1234567": "Anniversary Cruise"}
+    mock_cfg.show_promos = False
+    mock_cfg.date_display_format = "%m/%d/%Y"
+    mock_cfg.format_date = lambda d: str(d)
+    mock_cfg.paid_reservations = []
+    mock_cfg.history = MagicMock()
+
+    ship_dictionary = MagicMock()
+    ship_dictionary.get_ship.return_value = "Wonder of the Seas"
+    discounts = MagicMock()
+
+    with patch("CheckRoyalCaribbeanPrice.config", mock_cfg), \
+         patch("CheckRoyalCaribbeanPrice.log", MagicMock()), \
+         patch("CheckRoyalCaribbeanPrice._execute_api_request", side_effect=api_router), \
+         patch("CheckRoyalCaribbeanPrice.get_dining_and_prices",
+               return_value={"dining_selection": [], "prices": []}), \
+         patch("CheckRoyalCaribbeanPrice.get_checkin_info",
+               return_value=("Opens 12/10/2026 08:00 AM", None)), \
+         patch("CheckRoyalCaribbeanPrice.get_OBC", return_value=0.0), \
+         patch("CheckRoyalCaribbeanPrice.get_orders", MagicMock()):
+        get_voyages(account, discounts, ship_dictionary)
+
+    return mock_cfg, sail_date
+
+
+def test_get_voyages_calls_record_booking_with_full_snapshot():
+    """record_booking.call_args.kwargs carries reservation_id, ship_name, stateroom
+    fields (GTY -> None), guest_count, guests_json, loyalty, and final_payment_date."""
+    mock_cfg, sail_date = run_voyages_scenario()
+
+    mock_cfg.history.record_booking.assert_called_once()
+    kwargs = mock_cfg.history.record_booking.call_args.kwargs
+
+    assert kwargs["reservation_id"] == "1234567"
+    assert kwargs["ship_code"] == "WN"
+    assert kwargs["ship_name"] == "Wonder of the Seas"
+    assert kwargs["sail_date"] == sail_date
+    assert kwargs["nights"] == 7
+    assert kwargs["stateroom_type"] == "BALCONY"
+    assert kwargs["stateroom_number"] is None  # "GTY" -> None (not yet assigned)
+    assert kwargs["stateroom_category"] == "4D"
+    assert kwargs["guest_count"] == 2
+
+    guests = json.loads(kwargs["guests_json"])
+    assert {"name": "Matt", "id": "33333333", "age_bracket": "adult"} in guests
+    assert {"name": "Jane", "id": "44444444", "age_bracket": "child"} in guests
+
+    assert kwargs["loyalty_tier"] == "DIAMOND"
+    assert kwargs["loyalty_points"] == 4500
+    assert kwargs["checkin_label"] == "Opens 12/10/2026 08:00 AM"
+    assert kwargs["final_payment_date"] == get_final_payment_date(7, sail_date).strftime("%Y%m%d")
+    assert kwargs["past_final_payment"] == 0
+    assert kwargs["booking_currency"] == "USD"
+    assert kwargs["friendly_name"] == "Anniversary Cruise"
+    assert kwargs["account_label"] == "test_user"
+
+
+def test_get_voyages_record_booking_balance_due_tristate_true():
+    """An explicit balanceDue=True in the API payload maps to the tri-state 1."""
+    mock_cfg, _ = run_voyages_scenario(booking_extra={"balanceDue": True})
+    kwargs = mock_cfg.history.record_booking.call_args.kwargs
+    assert kwargs["balance_due"] == 1
+
+
+def test_get_voyages_record_booking_balance_due_tristate_false():
+    """An explicit balanceDue=False in the API payload maps to the tri-state 0."""
+    mock_cfg, _ = run_voyages_scenario(booking_extra={"balanceDue": False})
+    kwargs = mock_cfg.history.record_booking.call_args.kwargs
+    assert kwargs["balance_due"] == 0
+
+
+def test_get_voyages_record_booking_balance_due_tristate_unknown_ta_booking():
+    """No balance data and no TA/agency indicator -> derive_balance_due() returns
+    None (not the "TA_UNKNOWN" sentinel string) -> the tri-state stores NULL."""
+    mock_cfg, _ = run_voyages_scenario()
+    kwargs = mock_cfg.history.record_booking.call_args.kwargs
+    assert kwargs["balance_due"] is None
+
+
+# ---------------------------------------------------------------------------
+# get_all_promotions() integration: one record_promo call per promo
+# ---------------------------------------------------------------------------
+def test_get_all_promotions_calls_record_promo_once_per_promo():
+    """record_promo is called once per promo, carrying its title and validity dates."""
+    account = MagicMock()
+    account.username = "test_user"
+    account.api_brand = "royal"
+    booking = {"shipCode": "WN", "sailDate": "20270601", "bookingCurrency": "USD"}
+
+    homepage_promos = [
+        {"id": "P1", "startDate": "2027-06-01T00:00:00Z", "endDate": "2027-07-01T00:00:00Z",
+         "templates": [{"type": "HOME_HERO_LOCKUP", "categoryCode": "CRUISE_ONLY", "lockupMedia": {}}]},
+        {"id": "P2", "startDate": "2027-08-01T00:00:00Z", "endDate": "2027-09-01T00:00:00Z",
+         "templates": [{"type": "HOME_HERO_LOCKUP", "categoryCode": "", "lockupMedia": {}}]},
+    ]
+
+    def api_router(*args, **kwargs):
+        page = (kwargs.get("params") or {}).get("page")
+        resp = MagicMock()
+        resp.json.return_value = {"payload": homepage_promos if page == "homepage" else []}
+        return resp
+
+    mock_cfg = MagicMock()
+    mock_cfg.show_promos = True
+    mock_cfg.history = MagicMock()
+
+    with patch("CheckRoyalCaribbeanPrice.config", mock_cfg), \
+         patch("CheckRoyalCaribbeanPrice.log", MagicMock()), \
+         patch("CheckRoyalCaribbeanPrice._execute_api_request", side_effect=api_router):
+        get_all_promotions(account, booking)
+
+    assert mock_cfg.history.record_promo.call_count == 2
+    calls_by_id = {c.kwargs["promo_id"]: c.kwargs for c in mock_cfg.history.record_promo.call_args_list}
+
+    assert calls_by_id["P1"]["promo_title"] == "P1"
+    assert calls_by_id["P1"]["promo_start"] == "2027-06-01"
+    assert calls_by_id["P1"]["promo_end"] == "2027-07-01"
+    assert calls_by_id["P1"]["ship_code"] == "WN"
+    assert calls_by_id["P1"]["sail_date"] == "20270601"
+    assert calls_by_id["P1"]["account_label"] == "test_user"
+    assert "P1" in calls_by_id["P1"]["promo_line"]
+
+    assert calls_by_id["P2"]["promo_title"] == "P2"
+    assert calls_by_id["P2"]["promo_start"] == "2027-08-01"
+    assert calls_by_id["P2"]["promo_end"] == "2027-09-01"


### PR DESCRIPTION
Two follow-ups to the history layer (#103), both opt-in like it — nothing changes when `historyDb` is unset.

### 1. Every row for a reservation agrees on `sail_date` / `nights`

The cabin-fare row recorded `sail_date` from the URL the script builds (dashed, `2026-09-13`) and `nights` from a resolved value, while the add-on, promo and booking rows record the booking's raw `20260913` / `numberOfNights`. Any viewer grouping on those columns saw one reservation as two. Seen live: a reservation with add-on purchases rendered as two identical cards. The cabin path now records the booking's raw values; the URL and the checkout POST still carry the dashed date the API requires; synthetic watchlist bookings (no `sailDate`) keep the previous fallback. Tests pin the cabin and add-on paths to the same values for the same booking.

### 2. `bookings` and `promos` snapshot tables

The script already prints, every run, things a viewer otherwise has to re-derive: stateroom type/number/category, guests, loyalty tier, the check-in window, final-payment date and balance state, and the active sitewide promotions. Two new `CREATE TABLE IF NOT EXISTS` tables record them once per run (`record_booking` from the per-booking loop, `record_promo` from the promo loop), so the history is self-describing. Existing databases pick the tables up on next start; no behaviour change when history is off.

### Tests

Cross-path consistency tests (cabin vs add-on `sail_date`/`nights`); schema creation on a fresh and a pre-existing DB; `record_booking` / `record_promo` payloads captured end to end. Suite on this base: 217 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
